### PR TITLE
llvm-to-smt: handle select on pointers and phi on pointers

### DIFF
--- a/llvm-to-smt/generate_encodings.py
+++ b/llvm-to-smt/generate_encodings.py
@@ -473,6 +473,8 @@ if __name__ == "__main__":
     ###################
     print_and_log("Checkout kernel version v{}".format(args.kernver), pend="")
     cmd_checkout = ['git', 'checkout', '-f', '{}'.format(args.commit)]
+    print()
+    print(cmd_checkout)
     subprocess.run(cmd_checkout, stdout=logfile, stderr=logfile_err,
                    check=True, text=True, bufsize=1)
     print_and_log(" ... done")
@@ -515,6 +517,8 @@ if __name__ == "__main__":
         str(clang_fullpath)), 'V=1', 'KCFLAGS="-Wno-error"', 'kernel/bpf/verifier.o']
     cmdout_make_verifier = subprocess.run(
         cmd_make_verifier, stdout=subprocess.PIPE, stderr=logfile_err, text=True, bufsize=1, check=True)
+    print()
+    print(cmdout_make_verifier.stdout)
     logfile.write("cmdout_verifier:\n")
     logfile.write(cmdout_make_verifier.stdout)
     logfile.write("\n")

--- a/llvm-to-smt/llvm-passes/ForceFunctionEarlyExit/config.json
+++ b/llvm-to-smt/llvm-passes/ForceFunctionEarlyExit/config.json
@@ -3,6 +3,9 @@
         {"function": "sanitize_needed",  "return_value": 0},
         {"function": "sanitize_val_alu",  "return_value": 0},
         {"function": "can_skip_alu_sanitation",  "return_value": 1},
-        {"function": "update_alu_sanitation_state",  "return_value": 0}
+        {"function": "update_alu_sanitation_state",  "return_value": 0},
+        {"function": "reg_is_pkt_pointer_any",  "return_value": 0},
+        {"function": "__is_pointer_value",  "return_value": 0},
+        {"function": "reg_not_null",  "return_value": 1}
     ]
 }

--- a/llvm-to-smt/llvm-passes/InlineFunctionCalls/InlineFunctionCalls.hpp
+++ b/llvm-to-smt/llvm-passes/InlineFunctionCalls/InlineFunctionCalls.hpp
@@ -1,8 +1,8 @@
 #ifndef LLVM2SMT_INLINE_FUNCTION_CALLS_H
 #define LLVM2SMT_INLINE_FUNCTION_CALLS_H
 
-#include "llvm/IR/PassManager.h"
-#include "llvm/Pass.h"
+#include <llvm/IR/PassManager.h>
+#include <llvm/Pass.h>
 
 struct InlineFunctionCalls : public llvm::PassInfoMixin<InlineFunctionCalls> {
   llvm::PreservedAnalyses run(llvm::Module &M,

--- a/llvm-to-smt/llvm-passes/LLVMToSMT/BitvecHelper.cpp
+++ b/llvm-to-smt/llvm-passes/LLVMToSMT/BitvecHelper.cpp
@@ -14,7 +14,16 @@ z3::expr BitVecHelper::getBitVec(unsigned bitwidth, std::string prefix) {
                             "_" + std::to_string(BitVecHelper::unique_bv_id++);
   z3::expr ret = ctx.bv_const(unique_name.c_str(), bitwidth);
   outs() << "[getBitVec] "
-         << "returning uniq w prefix: " << ret.to_string().c_str() << "\n";
+         << "returning unique bitvector w/ prefix: " << ret.to_string().c_str() << "\n";
+  return ret;
+}
+
+z3::expr BitVecHelper::getBool(std::string prefix) {
+  std::string unique_name = prefix + "_" + BitVecHelper::global_bv_suffix +
+                            "_" + std::to_string(BitVecHelper::unique_bv_id++);
+  z3::expr ret = ctx.bool_const(unique_name.c_str());
+  outs() << "[getBool] "
+         << "returning unique bool w/ prefix: " << ret.to_string().c_str() << "\n";
   return ret;
 }
 

--- a/llvm-to-smt/llvm-passes/LLVMToSMT/BitvecHelper.hpp
+++ b/llvm-to-smt/llvm-passes/LLVMToSMT/BitvecHelper.hpp
@@ -21,6 +21,7 @@ private:
 public:
   static std::unordered_map<Value *, z3::expr> singleValueTypeMap;
   static z3::expr getBitVec(unsigned bitwidth, std::string = "");
+  static z3::expr getBool(std::string prefix);
   static z3::expr getBitVecSingValType(Value *);
   static bool isValueConstantInt(Value *);
   static int64_t getConstantIntValue(Value *);

--- a/llvm-to-smt/llvm-passes/LLVMToSMT/FunctionEncoder.cpp
+++ b/llvm-to-smt/llvm-passes/LLVMToSMT/FunctionEncoder.cpp
@@ -481,7 +481,20 @@ void FunctionEncoder::handleSelectInst(SelectInst &i) {
   Value *selectOp2 = i.getOperand(1);
   Value *selectOp3 = i.getOperand(2);
 
+  ValueBVTreeMap selectInstValueBVTreeMap =
+      MemoryAccessValueBVTreeMap.at(mostRecentMemoryDef);
+  printValueBVTreeMap(selectInstValueBVTreeMap);
+  ValuePair selectOperandsValuePair = std::make_pair(selectOp2, selectOp3);
+  SelectMap.insert({selectInstValue, selectOperandsValuePair});
+  outs() << "[handleSelectInst]"
+         << "SelectMap:"
+         << "\n";
+  printSelectMap();
+
   if (!selectInstValue->getType()->isPointerTy()) {
+    outs() << "[handleSelectInst]"
+           << "select instruction is not a pointer type:"
+           << "\n";
     auto z3ExprSelectOp1 = BitVecHelper::getBitVecSingValType(selectOp1);
     auto z3ExprSelectOp2 = BitVecHelper::getBitVecSingValType(selectOp2);
     auto z3ExprSelectOp3 = BitVecHelper::getBitVecSingValType(selectOp3);
@@ -504,18 +517,6 @@ void FunctionEncoder::handleSelectInst(SelectInst &i) {
            << "\n";
 
     BBAsstVecIter->second.push_back(selectEncoding);
-  } else {
-    /* Select instruction is a pointer type */
-    ValueBVTreeMap selectInstValueBVTreeMap =
-        MemoryAccessValueBVTreeMap.at(mostRecentMemoryDef);
-    printValueBVTreeMap(selectInstValueBVTreeMap);
-
-    ValuePair selectOperandsValuePair = std::make_pair(selectOp2, selectOp3);
-    SelectMap.insert({selectInstValue, selectOperandsValuePair});
-    outs() << "[handleSelectInst]"
-           << "SelectMap:"
-           << "\n";
-    printSelectMap();
   }
 }
 

--- a/llvm-to-smt/llvm-passes/LLVMToSMT/FunctionEncoder.hpp
+++ b/llvm-to-smt/llvm-passes/LLVMToSMT/FunctionEncoder.hpp
@@ -154,15 +154,19 @@ public:
   void handleGEPInstFromSelect(GetElementPtrInst &i);
   void handleGEPInstFromPHI(GetElementPtrInst &i);
   void handlePhiInstPointer(PHINode &inst);
-  void handleLoadFromSelect(LoadInst &i, GetElementPtrInst &GEP,
-                            SelectInst &selectInst);
-  void handleLoadFromPhi(LoadInst &i, GetElementPtrInst &GEP, PHINode &phiNode);
+  void handleLoadFromGEPPtrDerivedFromSelect(LoadInst &i,
+                                             SelectInst &selectInst);
+  void handleLoadFromGEPPtrDerivedFromPhi(LoadInst &i, PHINode &phiNode);
   void indexIntoBVTree(LoadInst &loadInst, BVTree *subTree);
-  void handleStoreFromSelect(StoreInst &i, GetElementPtrInst &GEP,
-                             SelectInst &selectInst,
-                             ValueBVTreeMap *newValueBVTreeMap);
-  void handleStoreFromPhi(StoreInst &storeInst, GetElementPtrInst &GEPInst,
-                          PHINode &phiInst, ValueBVTreeMap *newValueBVTreeMap);
+  void handleStoreToGEPPtrDerivedFromSelect(StoreInst &i,
+                                            SelectInst &selectInst,
+                                            ValueBVTreeMap *newValueBVTreeMap);
+  void handleStoreToGEPPtrDerivedFromPhi(StoreInst &storeInst, PHINode &phiInst,
+                                         ValueBVTreeMap *newValueBVTreeMap);
+  void handleStoreToPhiPtrDerivedFromGepPtrDerivedFromPhi(
+      StoreInst &storeInst, PHINode &phiInst,
+      ValueBVTreeMap *newValueBVTreeMap);
+
   /* Json output related functions */
   void populateInputAndOutputJsonDict();
   Json::Value *setupJSONDictForArg(Value *argVal);

--- a/llvm-to-smt/llvm-passes/LLVMToSMT/FunctionEncoder.hpp
+++ b/llvm-to-smt/llvm-passes/LLVMToSMT/FunctionEncoder.hpp
@@ -108,14 +108,15 @@ public:
    * preceded by a GEP */
   std::unordered_map<Value *, ValueIndicesPair> GEPMap;
 
+  std::unordered_map<Value *, ValuePair> SelectMap;
+
+  std::unordered_map<Value *, std::vector<ValueBBPair>> PhiMap;
+
   /* Associate with each BasicBlock, a ValueBVTreeMap; to resolve
    * to resolve insertValue instructions (instead of piggy-backing on the
    * MemoryAccessValueBVTreeMap). Used to store BVTrees for aggregate types.
    * Also used for handling struct return types. */
   std::unordered_map<BasicBlock *, ValueBVTreeMap *> BBValueBVTreeMap;
-
-  std::unordered_map<Value *, ValuePair> SelectMap;
-  std::unordered_map<Value *, ValueIndicesPair> SelectGEPMap;
 
   /* Functions to print things */
   void printEdgeAssertionsMap();

--- a/llvm-to-smt/llvm-passes/LLVMToSMT/FunctionEncoder.hpp
+++ b/llvm-to-smt/llvm-passes/LLVMToSMT/FunctionEncoder.hpp
@@ -149,7 +149,8 @@ public:
                             SelectInst &selectInst);
   void indexIntoBVTree(LoadInst &loadInst, BVTree *subTree);
   void handleStoreFromSelect(StoreInst &i, GetElementPtrInst &GEP,
-                             SelectInst &selectInst);
+                             SelectInst &selectInst,
+                             ValueBVTreeMap *newValueBVTreeMap);
 
   /* Json output related functions */
   void populateInputAndOutputJsonDict();

--- a/llvm-to-smt/llvm-passes/LLVMToSMT/FunctionEncoder.hpp
+++ b/llvm-to-smt/llvm-passes/LLVMToSMT/FunctionEncoder.hpp
@@ -129,7 +129,7 @@ public:
   void printMemoryPhiResolutionMap();
   void printGEPMap();
   void printSelectMap();
-  void printSelectGEPMap();
+  void printPhiMap();
   std::string GEPMapSingleElementToString(Value *v0, Value *v1,
                                           std::vector<int> *gepIndices);
   std::string stdVectorIntToString(std::vector<int> &vec);
@@ -144,14 +144,19 @@ public:
   void handleSelectInst(SelectInst &i);
   void handleBranchInst(BranchInst &i);
   void handlePhiNode(PHINode &inst, int passID);
+  void handlePhiNodeSetupBitVecs(PHINode &inst);
+  void handlePhiNodeResolvePathConditions(PHINode &inst);
   void handleGEPInst(GetElementPtrInst &i);
   void handleLoadInst(LoadInst &i);
   void handleStoreInst(StoreInst &i);
   void handleMemoryPhiNode(MemoryPhi &mphi, int passID);
   void handleCallInst(CallInst &i);
   void handleGEPInstFromSelect(GetElementPtrInst &i);
+  void handleGEPInstFromPHI(GetElementPtrInst &i);
+  void handlePhiInstPointer(PHINode &inst);
   void handleLoadFromSelect(LoadInst &i, GetElementPtrInst &GEP,
                             SelectInst &selectInst);
+  void handleLoadFromPhi(LoadInst &i, GetElementPtrInst &GEP, PHINode &phiNode);
   void indexIntoBVTree(LoadInst &loadInst, BVTree *subTree);
   void handleStoreFromSelect(StoreInst &i, GetElementPtrInst &GEP,
                              SelectInst &selectInst,

--- a/llvm-to-smt/llvm-passes/LLVMToSMT/FunctionEncoder.hpp
+++ b/llvm-to-smt/llvm-passes/LLVMToSMT/FunctionEncoder.hpp
@@ -157,15 +157,25 @@ public:
   void handleLoadFromGEPPtrDerivedFromSelect(LoadInst &i,
                                              SelectInst &selectInst);
   void handleLoadFromGEPPtrDerivedFromPhi(LoadInst &i, PHINode &phiNode);
-  void indexIntoBVTree(LoadInst &loadInst, BVTree *subTree);
-  void handleStoreToGEPPtrDerivedFromSelect(StoreInst &i,
+
+  void handleStoreToGEPPtrDerivedFromSelect(z3::expr BVToStore,
                                             SelectInst &selectInst,
-                                            ValueBVTreeMap *newValueBVTreeMap);
-  void handleStoreToGEPPtrDerivedFromPhi(StoreInst &storeInst, PHINode &phiInst,
-                                         ValueBVTreeMap *newValueBVTreeMap);
-  void handleStoreToPhiPtrDerivedFromGepPtrDerivedFromPhi(
-      StoreInst &storeInst, PHINode &phiInst,
-      ValueBVTreeMap *newValueBVTreeMap);
+                                            std::vector<int> *GEPMapIndices,
+                                            ValueBVTreeMap *newValueBVTreeMap,
+                                            MemoryUseOrDef *storeMemoryAccess);
+  void handleStoreToGEPPtrDerivedFromPhi(z3::expr BVToStore, PHINode &phiInst,
+                                         std::vector<int> *GEPMapIndices,
+                                         ValueBVTreeMap *newValueBVTreeMap,
+                                         MemoryUseOrDef *storeMemoryAccess);
+
+  void handleStoreToPhiPtr(z3::expr BVToStore, PHINode &phiPtrInst,
+                           ValueBVTreeMap *newValueBVTreeMap,
+                           MemoryUseOrDef *storeMemoryAccess);
+  void handleStoreToPhiPtrDerivedFromPhi(z3::expr BVToStore, PHINode &phiInst,
+                                         std::vector<int> *GEPMapIndices,
+                                         ValueBVTreeMap *newValueBVTreeMap,
+                                         MemoryUseOrDef *storeMemoryAccess,
+                                         z3::expr pathCondition);
 
   /* Json output related functions */
   void populateInputAndOutputJsonDict();

--- a/llvm-to-smt/llvm-passes/LLVMToSMT/FunctionEncoder.hpp
+++ b/llvm-to-smt/llvm-passes/LLVMToSMT/FunctionEncoder.hpp
@@ -161,7 +161,8 @@ public:
   void handleStoreFromSelect(StoreInst &i, GetElementPtrInst &GEP,
                              SelectInst &selectInst,
                              ValueBVTreeMap *newValueBVTreeMap);
-
+  void handleStoreFromPhi(StoreInst &storeInst, GetElementPtrInst &GEPInst,
+                          PHINode &phiInst, ValueBVTreeMap *newValueBVTreeMap);
   /* Json output related functions */
   void populateInputAndOutputJsonDict();
   Json::Value *setupJSONDictForArg(Value *argVal);

--- a/llvm-to-smt/llvm-passes/LLVMToSMT/FunctionEncoder.hpp
+++ b/llvm-to-smt/llvm-passes/LLVMToSMT/FunctionEncoder.hpp
@@ -28,6 +28,7 @@ typedef std::pair<BasicBlock *, BasicBlock *> BBPair;
 typedef std::unordered_map<Value *, BVTree *> ValueBVTreeMap;
 typedef std::pair<Value *, Value *> ValuePair;
 typedef std::pair<Value *, std::vector<int> *> ValueIndicesPair;
+typedef std::pair<Value *, BasicBlock *> ValueBBPair;
 
 extern z3::context ctx;
 
@@ -75,9 +76,11 @@ public:
    * ValueBVTreeMap containing all the functions arguments as keys. eg.
    * liveOnEntry: [arg_a: [bv_a_1, bv_a_2, bv_a_3], arg_b: [bv_b]] */
   std::unordered_map<MemoryAccess *, ValueBVTreeMap> MemoryAccessValueBVTreeMap;
+  std::unordered_map<BBPair, z3::expr, pair_hash<BasicBlock *, BasicBlock *>>
+      PhiResolutionMap;
   std::unordered_map<BBPair, z3::expr_vector,
                      pair_hash<BasicBlock *, BasicBlock *>>
-      phiResolutionMap;
+      MemoryPhiResolutionMap;
 
   /* A list of structs relevent to the encoding. All other structs are ignored
    * when creating BVTrees. */
@@ -122,6 +125,7 @@ public:
   void printValueBVTreeMap(ValueBVTreeMap vt);
   void printMemoryAccessValueBVTreeMap();
   void printPhiResolutionMap();
+  void printMemoryPhiResolutionMap();
   void printGEPMap();
   void printSelectMap();
   void printSelectGEPMap();

--- a/llvm-to-smt/llvm-passes/LowerFunnelShifts/CMakeLists.txt
+++ b/llvm-to-smt/llvm-passes/LowerFunnelShifts/CMakeLists.txt
@@ -1,0 +1,40 @@
+cmake_minimum_required(VERSION 3.13.4)
+project(llvm-to-smt)
+
+#===============================================================================
+# 1. LOAD LLVM CONFIGURATION
+#===============================================================================
+# Set this to a valid LLVM installation dir
+set(LT_LLVM_INSTALL_DIR "" CACHE PATH "LLVM installation directory")
+
+# Add the location of LLVMConfig.cmake to CMake search paths (so that
+# find_package can locate it)
+list(APPEND CMAKE_PREFIX_PATH "${LT_LLVM_INSTALL_DIR}/lib/cmake/llvm/")
+
+find_package(LLVM 12.0.0 REQUIRED CONFIG)
+
+# LLVMToSMT includes headers from LLVM - update the include paths accordingly
+include_directories(SYSTEM ${LLVM_INCLUDE_DIRS})
+
+#===============================================================================
+# 2. REMOVE_FUNCTION_AND_USES BUILD CONFIGURATION
+#===============================================================================
+# Use the same C++ standard as LLVM does
+set(CMAKE_CXX_STANDARD 14 CACHE STRING "")
+
+# LLVM is normally built without RTTI. Be consistent with that.
+if(NOT LLVM_ENABLE_RTTI)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti")
+endif()
+
+set(CMAKE_BUILD_TYPE Debug)
+
+#===============================================================================
+# 3. ADD THE TARGET
+#===============================================================================
+add_library(LowerFunnelShifts SHARED LowerFunnelShifts.cpp)
+
+# Allow undefined symbols in shared objects on Darwin (this is the default
+# behaviour on Linux)
+target_link_libraries(LowerFunnelShifts
+  "$<$<PLATFORM_ID:Darwin>:-undefined dynamic_lookup>")

--- a/llvm-to-smt/llvm-passes/LowerFunnelShifts/LowerFunnelShifts.cpp
+++ b/llvm-to-smt/llvm-passes/LowerFunnelShifts/LowerFunnelShifts.cpp
@@ -1,0 +1,289 @@
+//=============================================================================
+// FILE:
+//    LowerFunnelShifts.cpp
+//
+// DESCRIPTION:
+//   Lower llvm.fshl and llvm.fshr calls to a separate function
+//
+//=============================================================================
+#include "LowerFunnelShifts.hpp"
+#include <llvm/IR/Attributes.h>
+#include <llvm/IR/IntrinsicInst.h>
+#include <llvm/Transforms/Utils/Cloning.h>
+
+#define DEBUG_TYPE "lower-funnel-shifts"
+using namespace llvm;
+
+Function *getOrCreateFunction(Module *M, Type *RetTy, ArrayRef<Type *> ArgTypes,
+                              StringRef Name) {
+  FunctionType *FT = FunctionType::get(RetTy, ArgTypes, false);
+  Function *F = M->getFunction(Name);
+  if (F && F->getFunctionType() == FT)
+    return F;
+  Function *NewF = Function::Create(FT, GlobalValue::ExternalLinkage, Name, M);
+  if (F)
+    NewF->setDSOLocal(F->isDSOLocal());
+  NewF->setCallingConv(CallingConv::C);
+  return NewF;
+}
+
+std::string lowerLLVMIntrinsicName(IntrinsicInst *II) {
+  Function *IntrinsicFunc = II->getCalledFunction();
+  assert(IntrinsicFunc && "Missing function");
+  std::string FuncName = IntrinsicFunc->getName().str();
+  std::replace(FuncName.begin(), FuncName.end(), '.', '_');
+  FuncName = "spirv." + FuncName;
+  return FuncName;
+}
+
+void lowerFunnelShifts(IntrinsicInst *FSHIntrinsic) {
+  // Get a separate function - otherwise, we'd have to rework the CFG of the
+  // current one. Then simply replace the intrinsic uses with a call to the new
+  // function.
+  // Generate LLVM IR for  i* @spirv.llvm_fsh?_i* (i* %a, i* %b, i* %c)
+  Module *M = FSHIntrinsic->getModule();
+  FunctionType *FSHFuncTy = FSHIntrinsic->getFunctionType();
+  Type *FSHRetTy = FSHFuncTy->getReturnType();
+  const std::string FuncName = lowerLLVMIntrinsicName(FSHIntrinsic);
+  Function *FSHFunc =
+      getOrCreateFunction(M, FSHRetTy, FSHFuncTy->params(), FuncName);
+  FSHFunc->addFnAttr("optnone");
+  if (!FSHFunc->empty()) {
+    FSHIntrinsic->setCalledFunction(FSHFunc);
+    return;
+  }
+  BasicBlock *RotateBB = BasicBlock::Create(M->getContext(), "rotate", FSHFunc);
+  IRBuilder<> IRB(RotateBB);
+  Type *Ty = FSHFunc->getReturnType();
+  // Build the actual funnel shift rotate logic.
+  // In the comments, "int" is used interchangeably with "vector of int
+  // elements".
+  FixedVectorType *VectorTy = dyn_cast<FixedVectorType>(Ty);
+  Type *IntTy = VectorTy ? VectorTy->getElementType() : Ty;
+  unsigned BitWidth = IntTy->getIntegerBitWidth();
+  ConstantInt *BitWidthConstant = IRB.getInt({BitWidth, BitWidth});
+  Value *BitWidthForInsts =
+      VectorTy
+          ? IRB.CreateVectorSplat(VectorTy->getNumElements(), BitWidthConstant)
+          : BitWidthConstant;
+  Value *RotateModVal =
+      IRB.CreateURem(/*Rotate*/ FSHFunc->getArg(2), BitWidthForInsts);
+  Value *FirstShift = nullptr, *SecShift = nullptr;
+  if (FSHIntrinsic->getIntrinsicID() == Intrinsic::fshr) {
+    // Shift the less significant number right, the "rotate" number of bits
+    // will be 0-filled on the left as a result of this regular shift.
+    FirstShift = IRB.CreateLShr(FSHFunc->getArg(1), RotateModVal);
+  } else {
+    // Shift the more significant number left, the "rotate" number of bits
+    // will be 0-filled on the right as a result of this regular shift.
+    FirstShift = IRB.CreateShl(FSHFunc->getArg(0), RotateModVal);
+  }
+  // We want the "rotate" number of the more significant int's LSBs (MSBs) to
+  // occupy the leftmost (rightmost) "0 space" left by the previous operation.
+  // Therefore, subtract the "rotate" number from the integer bitsize...
+  Value *SubRotateVal = IRB.CreateSub(BitWidthForInsts, RotateModVal);
+  if (FSHIntrinsic->getIntrinsicID() == Intrinsic::fshr) {
+    // ...and left-shift the more significant int by this number, zero-filling
+    // the LSBs.
+    SecShift = IRB.CreateShl(FSHFunc->getArg(0), SubRotateVal);
+  } else {
+    // ...and right-shift the less significant int by this number, zero-filling
+    // the MSBs.
+    SecShift = IRB.CreateLShr(FSHFunc->getArg(1), SubRotateVal);
+  }
+  // A simple binary addition of the shifted ints yields the final result.
+  IRB.CreateRet(IRB.CreateOr(FirstShift, SecShift));
+
+  FSHIntrinsic->setCalledFunction(FSHFunc);
+}
+
+#if 0
+static bool lowerIntrinsicToFunction(IntrinsicInst *Intrinsic) {
+  // For @llvm.memset.* intrinsic cases with constant value and length arguments
+  // are emulated via "storing" a constant array to the destination. For other
+  // cases we wrap the intrinsic in @spirv.llvm_memset_* function and expand the
+  // intrinsic to a loop via expandMemSetAsLoop().
+  if (auto *MSI = dyn_cast<MemSetInst>(Intrinsic))
+    if (isa<Constant>(MSI->getValue()) && isa<ConstantInt>(MSI->getLength()))
+      return false; // It is handled later using OpCopyMemorySized.
+ 
+  Module *M = Intrinsic->getModule();
+  std::string FuncName = lowerLLVMIntrinsicName(Intrinsic);
+  // Redirect @llvm.intrinsic.* call to @spirv.llvm_intrinsic_*
+  Function *F = M->getFunction(FuncName);
+  if (F) {
+    Intrinsic->setCalledFunction(F);
+    return true;
+  }
+  // TODO copy arguments attributes: nocapture writeonly.
+  FunctionCallee FC =
+      M->getOrInsertFunction(FuncName, Intrinsic->getFunctionType());
+  auto IntrinsicID = Intrinsic->getIntrinsicID();
+  Intrinsic->setCalledFunction(FC);
+ 
+  F = dyn_cast<Function>(FC.getCallee());
+  assert(F && "Callee must be a function");
+  return true;
+}
+#endif
+
+// Substitutes calls to LLVM intrinsics with either calls to SPIR-V intrinsics
+// or calls to proper generated functions. Returns True if F was modified.
+bool substituteIntrinsicCalls(Function *F) {
+  bool Changed = false;
+  for (BasicBlock &BB : *F) {
+    for (Instruction &I : BB) {
+      auto Call = dyn_cast<CallInst>(&I);
+      if (!Call)
+        continue;
+      Function *CF = Call->getCalledFunction();
+      if (!CF || !CF->isIntrinsic())
+        continue;
+      auto *II = cast<IntrinsicInst>(Call);
+#if 0
+      if (II->getIntrinsicID() == Intrinsic::memset ||
+          II->getIntrinsicID() == Intrinsic::bswap)
+        Changed |= lowerIntrinsicToFunction(II);
+      else
+#endif
+      if (II->getIntrinsicID() == Intrinsic::fshl ||
+          II->getIntrinsicID() == Intrinsic::fshr) {
+        lowerFunnelShifts(II);
+        outs() << "[substituteIntrinsicCalls] lowered fshl in function: "
+               << F->getName() << "\n";
+        Changed = true;
+      }
+    }
+  }
+  return Changed;
+}
+
+#if 0
+// Returns F if aggregate argument/return types are not present or cloned F
+// function with the types replaced by i32 types. The change in types is
+// noted in 'spv.cloned_funcs' metadata for later restoration.
+Function *
+removeAggregateTypesFromSignature(Function *F) {
+  IRBuilder<> B(F->getContext());
+ 
+  bool IsRetAggr = F->getReturnType()->isAggregateType();
+  bool HasAggrArg =
+      std::any_of(F->arg_begin(), F->arg_end(), [](Argument &Arg) {
+        return Arg.getType()->isAggregateType();
+      });
+  bool DoClone = IsRetAggr || HasAggrArg;
+  if (!DoClone)
+    return F;
+  SmallVector<std::pair<int, Type *>, 4> ChangedTypes;
+  Type *RetType = IsRetAggr ? B.getInt32Ty() : F->getReturnType();
+  if (IsRetAggr)
+    ChangedTypes.push_back(std::pair<int, Type *>(-1, F->getReturnType()));
+  SmallVector<Type *, 4> ArgTypes;
+  for (const auto &Arg : F->args()) {
+    if (Arg.getType()->isAggregateType()) {
+      ArgTypes.push_back(B.getInt32Ty());
+      ChangedTypes.push_back(
+          std::pair<int, Type *>(Arg.getArgNo(), Arg.getType()));
+    } else
+      ArgTypes.push_back(Arg.getType());
+  }
+  FunctionType *NewFTy =
+      FunctionType::get(RetType, ArgTypes, F->getFunctionType()->isVarArg());
+  Function *NewF =
+      Function::Create(NewFTy, F->getLinkage(), F->getName(), *F->getParent());
+ 
+  ValueToValueMapTy VMap;
+  auto NewFArgIt = NewF->arg_begin();
+  for (auto &Arg : F->args()) {
+    StringRef ArgName = Arg.getName();
+    NewFArgIt->setName(ArgName);
+    VMap[&Arg] = &(*NewFArgIt++);
+  }
+  SmallVector<ReturnInst *, 8> Returns;
+  llvm::CloneFunctionInto(NewF, F, VMap, false,
+                    Returns);
+  NewF->takeName(F);
+ 
+  NamedMDNode *FuncMD =
+      F->getParent()->getOrInsertNamedMetadata("spv.cloned_funcs");
+  SmallVector<Metadata *, 2> MDArgs;
+  MDArgs.push_back(MDString::get(B.getContext(), NewF->getName()));
+  for (auto &ChangedTyP : ChangedTypes)
+    MDArgs.push_back(MDNode::get(
+        B.getContext(),
+        {ConstantAsMetadata::get(B.getInt32(ChangedTyP.first)),
+         ValueAsMetadata::get(Constant::getNullValue(ChangedTyP.second))}));
+  MDNode *ThisFuncMD = MDNode::get(B.getContext(), MDArgs);
+  FuncMD->addOperand(ThisFuncMD);
+ 
+  for (auto *U : make_early_inc_range(F->users())) {
+    if (auto *CI = dyn_cast<CallInst>(U))
+      CI->mutateFunctionType(NewF->getFunctionType());
+    U->replaceUsesOfWith(F, NewF);
+  }
+  return NewF;
+}
+#endif
+
+bool runOnModule(Module &M) {
+  bool Changed = false;
+  char *functionToLowerFunnelShifts =
+      std::getenv("FUNCTION_TO_LOWER_FUNNEL_SHIFTS");
+  if (!functionToLowerFunnelShifts) {
+    throw std::invalid_argument(
+        "No function specified. Please set the FUNCTION_TO_LOWER_FUNNEL_SHIFTS "
+        "environment variable.\n");
+  }
+  for (Function &F : M) {
+    // if (F.getName() != functionToLowerFunnelShifts)
+    //   continue;
+    Changed |= substituteIntrinsicCalls(&F);
+  }
+
+#if 0
+  std::vector<Function *> FuncsWorklist;
+  for (auto &F : M)
+    FuncsWorklist.push_back(&F);
+ 
+  for (auto *F : FuncsWorklist) {
+    Function *NewF = removeAggregateTypesFromSignature(F);
+ 
+    if (NewF != F) {
+      F->eraseFromParent();
+      Changed = true;
+    }
+  }
+#endif
+  return Changed;
+}
+
+PreservedAnalyses LowerFunnelShifts::run(llvm::Module &M,
+                                         llvm::ModuleAnalysisManager &MAM) {
+
+  bool Changed = runOnModule(M);
+  return (Changed ? llvm::PreservedAnalyses::none()
+                  : llvm::PreservedAnalyses::all());
+}
+
+//-----------------------------------------------------------------------------
+// New PM Registration
+//-----------------------------------------------------------------------------
+llvm::PassPluginLibraryInfo getLowerFunnelShiftsPluginInfo() {
+  return {LLVM_PLUGIN_API_VERSION, "lower-funnel-shifts", LLVM_VERSION_STRING,
+          [](PassBuilder &PB) {
+            PB.registerPipelineParsingCallback(
+                [](StringRef Name, ModulePassManager &MPM,
+                   ArrayRef<PassBuilder::PipelineElement>) {
+                  if (Name == "lower-funnel-shifts") {
+                    MPM.addPass(LowerFunnelShifts());
+                    return true;
+                  }
+                  return false;
+                });
+          }};
+}
+
+extern "C" LLVM_ATTRIBUTE_WEAK ::llvm::PassPluginLibraryInfo
+llvmGetPassPluginInfo() {
+  return getLowerFunnelShiftsPluginInfo();
+}

--- a/llvm-to-smt/llvm-passes/LowerFunnelShifts/LowerFunnelShifts.hpp
+++ b/llvm-to-smt/llvm-passes/LowerFunnelShifts/LowerFunnelShifts.hpp
@@ -1,5 +1,5 @@
-#ifndef LLVM2SMT_PROMOTE_MEMCPY_H
-#define LLVM2SMT_PROMOTE_MEMCPY_H
+#ifndef LLVM2SMT_LOWER_FUNNEL_SHIFTS_H
+#define LLVM2SMT_LOWER_FUNNEL_SHIFTS_H
 
 #include <llvm/IR/PassManager.h>
 #include <llvm/IR/IntrinsicInst.h>
@@ -35,4 +35,4 @@ private:
   llvm::Module *module;
   llvm::LLVMContext *context;
 };
-#endif // LLVM2SMT_PROMOTE_MEMCPY_H
+#endif // LLVM2SMT_LOWER_FUNNEL_SHIFTS_H

--- a/llvm-to-smt/llvm-passes/LowerFunnelShifts/LowerFunnelShifts.hpp
+++ b/llvm-to-smt/llvm-passes/LowerFunnelShifts/LowerFunnelShifts.hpp
@@ -1,0 +1,38 @@
+#ifndef LLVM2SMT_PROMOTE_MEMCPY_H
+#define LLVM2SMT_PROMOTE_MEMCPY_H
+
+#include <llvm/IR/PassManager.h>
+#include <llvm/IR/IntrinsicInst.h>
+#include <llvm/IR/IRBuilder.h>
+#include <llvm/Passes/PassBuilder.h>
+#include <llvm/Passes/PassPlugin.h>
+
+
+// https://github.com/intel/llvm/blob/97d7eec5a71e0b28f688600f3666ae6eaff0403d/llvm-spirv/lib/SPIRV/SPIRVRegularizeLLVM.cpp
+// https://llvm.org/doxygen/SPIRVPrepareFunctions_8cpp_source.html
+
+struct LowerFunnelShifts : llvm::PassInfoMixin<LowerFunnelShifts> {
+  llvm::PreservedAnalyses run(llvm::Module &M, llvm::ModuleAnalysisManager &);
+  // bool runOnModule(llvm::Module &M);
+
+  // std::string lowerLLVMIntrinsicName(llvm::IntrinsicInst *II);
+
+  /// No SPIR-V counterpart for @llvm.fshl.i* intrinsic. It will be lowered
+  /// to a newly generated @spirv.llvm_fshl_i* function.
+  /// Conceptually, FSHL:
+  /// 1. concatenates the ints, the first one being the more significant;
+  /// 2. performs a left shift-rotate on the resulting doubled-sized int;
+  /// 3. returns the most significant bits of the shift-rotate result,
+  ///    the number of bits being equal to the size of the original integers.
+  /// The actual implementation algorithm will be slightly different to speed
+  /// things up.
+  // void lowerFunnelShifts(llvm::IntrinsicInst *FSHIntrinsic);
+  // void lowerFunnelShiftLeft(llvm::IntrinsicInst *FSHLIntrinsic);
+  // void buildFunnelShiftLeftFunc(llvm::Function *FSHLFunc);
+
+
+private:
+  llvm::Module *module;
+  llvm::LLVMContext *context;
+};
+#endif // LLVM2SMT_PROMOTE_MEMCPY_H

--- a/llvm-to-smt/llvm-passes/inline_verifier_func.sh
+++ b/llvm-to-smt/llvm-passes/inline_verifier_func.sh
@@ -7,8 +7,8 @@ fi
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 source ${SCRIPT_DIR}/.config
-INLINE_FUNCTION_CALLS_PASS_DIR="${BASE_DIR}/InlineFunctionCalls"
-BUILD_DIR="${INLINE_FUNCTION_CALLS_PASS_DIR}/build"
+PASS_DIR="${BASE_DIR}/InlineFunctionCalls"
+BUILD_DIR="${PASS_DIR}/build"
 
 oldpwd=$(pwd)
 inputllfile=$(readlink -f $1)
@@ -21,10 +21,11 @@ echo "outfile_final ${outfile_final}"
 echo "--------------------------------------"
 echo "build InlineFunctionCalls pass"
 echo "--------------------------------------"
-cmd="cd ${BUILD_DIR}"
+cmd="mkdir -p ${BUILD_DIR}"
+cmd="${cmd} && cd ${BUILD_DIR}"
 cmd="${cmd} && export CC=${LLVM_DIR}/bin/clang"
 cmd="${cmd} && export CXX=${LLVM_DIR}/bin/clang++"
-cmd="${cmd} && cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=1 -DLT_LLVM_INSTALL_DIR=${LLVM_DIR} ${INLINE_FUNCTION_CALLS_PASS_DIR}"
+cmd="${cmd} && cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=1 -DLT_LLVM_INSTALL_DIR=${LLVM_DIR} ${PASS_DIR}"
 cmd="${cmd} && make"
 echo $cmd
 eval $cmd || exit 1
@@ -39,12 +40,6 @@ cmd="$LLVM_DIR/bin/opt -load-pass-plugin ${BUILD_DIR}/libInlineFunctionCalls.so 
 
 echo $cmd
 eval $cmd || exit 1
-
-# cmd="${LLVM_DIR}/bin/opt -S --strip-debug ${outfile_final} -o ${outfile_final}.ll"
-# cmd="${cmd} && mv ${outfile_final}.ll ${outfile_final}"
-
-# echo $cmd
-# eval $cmd || exit 1
 
 # echo "--------------------------------------"
 # echo "running verify pass "

--- a/llvm-to-smt/llvm-passes/lower_funnel_shifts.sh
+++ b/llvm-to-smt/llvm-passes/lower_funnel_shifts.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+if [ $# -ne 4 ]; then
+    echo "$0: Usage: lower_funnel_shifts.sh path_to_llvm_file.ll function_to_lower_funnel_shifts out_dir output_file.ll"
+    exit 1
+fi
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+source ${SCRIPT_DIR}/.config
+PASS_DIR="${BASE_DIR}/LowerFunnelShifts"
+BUILD_DIR="${PASS_DIR}/build"
+
+oldpwd=$(pwd)
+inputllfile=$(readlink -f $1)
+function_name=$2
+outfile_final_dir=$(readlink -f $3)
+outfile_final_name=$4
+outfile_final="${outfile_final_dir}/${outfile_final_name}"
+echo "outfile_final ${outfile_final}"
+
+echo "--------------------------------------"
+echo "build LowerFunnelShifts pass"
+echo "--------------------------------------"
+cmd="mkdir -p ${BUILD_DIR}"
+cmd="${cmd} && cd ${BUILD_DIR}"
+cmd="${cmd} && export CC=${LLVM_DIR}/bin/clang"
+cmd="${cmd} && export CXX=${LLVM_DIR}/bin/clang++"
+cmd="${cmd} && cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=1 -DLT_LLVM_INSTALL_DIR=${LLVM_DIR} ${PASS_DIR}"
+cmd="${cmd} && make"
+echo $cmd
+eval $cmd || exit 1
+
+export FUNCTION_TO_LOWER_FUNNEL_SHIFTS=${function_name}
+echo "FUNCTION_TO_LOWER_FUNNEL_SHIFTS: ${FUNCTION_TO_LOWER_FUNNEL_SHIFTS}"
+echo "--------------------------------------"
+echo "running pass lower-funnel-shifts"
+echo "--------------------------------------"
+cmd="$LLVM_DIR/bin/opt -load-pass-plugin ${BUILD_DIR}/libLowerFunnelShifts.so --passes=\"lower-funnel-shifts\" ${inputllfile} -S -o ${outfile_final}"
+
+echo $cmd
+eval $cmd || exit 1
+
+echo "--------------------------------------"
+echo "done. output file: ${outfile_final}"
+echo "--------------------------------------"
+

--- a/llvm-to-smt/run_llvm_passes.py
+++ b/llvm-to-smt/run_llvm_passes.py
@@ -1,161 +1,296 @@
 import subprocess
 import sys
+import argparse
+from shutil import copy2
+from pathlib import Path
+from datetime import datetime
 
 
 class LLVMPassRunner:
 
     def __init__(self, logfile, logfile_err, scriptsdir_fullpath,
                  llvmdir_fullpath,
-                 inputdir_fullpath, op, input_llfile_name, 
+                 inputdir_fullpath,
+                 input_llfile_fullpath,
+                 op,
                  function_name, output_smtfile_name,
                  global_bv_suffix):
         self.logfile = logfile
         self.logfile_err = logfile_err
         self.scriptsdir_fullpath = scriptsdir_fullpath
         self.llvmdir_fullpath = llvmdir_fullpath
-        self.inputdir_fullpath = inputdir_fullpath
+        self.parentdir_fullpath = inputdir_fullpath
         self.op = op
-        self.input_llfile_name = input_llfile_name
+        self.input_llfile_fullpath = input_llfile_fullpath
+        self.curr_llfile_fullpath = self.input_llfile_fullpath
         self.function_name = function_name
         self.output_smtfile_name = output_smtfile_name
         self.global_bv_suffix = global_bv_suffix
+        self.op_dir_fullpath = self.parentdir_fullpath.joinpath(
+            '{}'.format(self.op))
 
-    def run_opt_pass(self, input_llfile_fullpath, output_llfile_fullpath, O1=True):
+    def create_op_dir(self):
+        self.logfile.write(
+            "Creating directory and file for op: {}\n".format(self.op))
+        try:
+            self.op_dir_fullpath.mkdir()
+        except FileExistsError:
+            pass
+        op_llfile_fullpath = self.op_dir_fullpath.joinpath(
+            '{}.ll'.format(self.op))
+        # print(op_llfile_fullpath)
+        copy2(str(self.input_llfile_fullpath), str(op_llfile_fullpath))
+        self.curr_llfile_fullpath = op_llfile_fullpath
+
+    def run_opt_pass(self, O1=True):
         llvm_opt_fullpath = self.llvmdir_fullpath.joinpath("bin", "opt")
         cmd_opt_O1 = '''{llvm_opt_fullpath} -O1 --strip-debug --instnamer --stats -S  {input_llfile_fullpath} -o {output_llfile_fullpath}'''
         cmd_opt_O0 = '''{llvm_opt_fullpath} -S --instnamer --simplifycfg --sroa --mergereturn --dce --deadargelim --memoryssa --always-inline --function-attrs --argpromotion --instcombine {input_llfile_fullpath} -o {output_llfile_fullpath}'''
         if O1 == True:
+            output_llfile_fullpath = self.curr_llfile_fullpath.parent.joinpath(
+                self.curr_llfile_fullpath.stem + ".O1" + ".ll")
             cmd_opt = cmd_opt_O1.format(
                 llvm_opt_fullpath=llvm_opt_fullpath,
-                input_llfile_fullpath=input_llfile_fullpath,
+                input_llfile_fullpath=str(self.curr_llfile_fullpath),
                 output_llfile_fullpath=output_llfile_fullpath
             )
             self.logfile.write("Running opt -O1\n")
             self.logfile.write(cmd_opt)
             self.logfile.write("\n")
         else:
+            output_llfile_fullpath = self.curr_llfile_fullpath.parent.joinpath(
+                self.curr_llfile_fullpath.stem + ".O0" + ".ll")
             cmd_opt = cmd_opt_O0.format(
                 llvm_opt_fullpath=llvm_opt_fullpath,
-                input_llfile_fullpath=input_llfile_fullpath,
+                input_llfile_fullpath=str(self.curr_llfile_fullpath),
                 output_llfile_fullpath=output_llfile_fullpath
-
             )
             self.logfile.write("Running opt -O0\n")
             self.logfile.write(cmd_opt)
             self.logfile.write("\n")
+        # print(cmd_opt)
         subprocess.run(cmd_opt, shell=True, check=True, text=True,
                        stdout=self.logfile, stderr=self.logfile_err, bufsize=1)
         self.logfile.write("\nFinished running opt\n")
+        self.curr_llfile_fullpath = output_llfile_fullpath
 
-    def run_force_function_early_exit_pass(self, input_llfile_fullpath, outdir_fullpath, output_llfile_name):
+    def run_force_function_early_exit_pass(self):
         cmd_force_functions_early_exit = '''{force_functions_early_exit_pass_runner_sh} {path_to_llvm_file} {output_dir} {output_filename_ll}'''
         force_functions_early_exit_pass_fullpath = self.scriptsdir_fullpath.joinpath(
             "force_functions_early_exit.sh")
+        output_llfile_fullpath = self.curr_llfile_fullpath.parent.joinpath(
+            self.curr_llfile_fullpath.stem + ".ffee" + ".ll")
         cmd_force_functions_early_exit_op = cmd_force_functions_early_exit.format(
             force_functions_early_exit_pass_runner_sh=force_functions_early_exit_pass_fullpath,
-            path_to_llvm_file=input_llfile_fullpath,
-            output_dir=outdir_fullpath,
-            output_filename_ll=output_llfile_name
+            path_to_llvm_file=self.curr_llfile_fullpath,
+            output_dir=output_llfile_fullpath.parent,
+            output_filename_ll=output_llfile_fullpath.name
         )
         self.logfile.write("Running force_function_early_exit_pass\n")
         self.logfile.write(cmd_force_functions_early_exit_op)
         self.logfile.write("\n")
+        # print(cmd_force_functions_early_exit_op)
         subprocess.run(cmd_force_functions_early_exit_op, shell=True, check=True,
                        text=True, stdout=self.logfile, stderr=self.logfile_err, bufsize=1)
         self.logfile.write("\nFinished force_function_early_exit_pass\n")
+        self.curr_llfile_fullpath = output_llfile_fullpath
 
-    def run_remove_functions_calls_pass(self, input_llfile_fullpath, function_name, outdir_fullpath, output_llfile_name):
+    def run_remove_functions_calls_pass(self):
         remove_func_calls_pass_fullpath = self.scriptsdir_fullpath.joinpath(
             "remove_func_calls.sh")
         cmd_remove_func_calls = '''{remove_func_calls_pass_runner_sh} {path_to_llvm_file} {function_to_start_remove} {output_dir} {output_filename_ll}'''
+        output_llfile_fullpath = self.curr_llfile_fullpath.parent.joinpath(
+            self.curr_llfile_fullpath.stem + ".rfc" + ".ll")
         cmd_remove_func_calls_op = cmd_remove_func_calls.format(
             remove_func_calls_pass_runner_sh=remove_func_calls_pass_fullpath,
-            path_to_llvm_file=input_llfile_fullpath,
-            function_to_start_remove=function_name,
-            output_dir=outdir_fullpath,
-            output_filename_ll=output_llfile_name
+            path_to_llvm_file=self.curr_llfile_fullpath,
+            function_to_start_remove=self.function_name,
+            output_dir=output_llfile_fullpath.parent,
+            output_filename_ll=output_llfile_fullpath.name
         )
         self.logfile.write("Running remove_functions_calls_pass\n")
         self.logfile.write(cmd_remove_func_calls_op)
         self.logfile.write("\n")
+        # print(cmd_remove_func_calls_op)
         subprocess.run(cmd_remove_func_calls_op, shell=True, check=True, text=True,
                        stdout=self.logfile, stderr=self.logfile_err, bufsize=1)
         self.logfile.write("\nFinished remove_functions_calls_pass\n")
+        self.curr_llfile_fullpath = output_llfile_fullpath
 
-    def run_inline_verifier_func_pass(self, input_llfile_fullpath, function_name, outdir_fullpath, output_llfile_name):
+    def run_lower_funnel_shifts_pass(self):
+        lower_funnel_shifts_fullpath = self.scriptsdir_fullpath.joinpath(
+            "lower_funnel_shifts.sh")
+        cmd_lower_funnel_shifts = '''{lower_funnel_shifts_pass_runner_sh} {path_to_llvm_file} {function_name} {output_dir} {output_filename_ll}'''
+        output_llfile_fullpath = self.curr_llfile_fullpath.parent.joinpath(
+            self.curr_llfile_fullpath.stem + ".lfsh" + ".ll")
+        cmd_lower_funnel_shifts_op = cmd_lower_funnel_shifts.format(
+            lower_funnel_shifts_pass_runner_sh=lower_funnel_shifts_fullpath,
+            path_to_llvm_file=self.curr_llfile_fullpath,
+            function_name=self.function_name,  # TODO, and fix cpp,sh as well.
+            output_dir=output_llfile_fullpath.parent,
+            output_filename_ll=output_llfile_fullpath.name
+        )
+        self.logfile.write("Running lower_funnel_shifts_pass\n")
+        self.logfile.write(cmd_lower_funnel_shifts_op)
+        self.logfile.write("\n")
+        # print(cmd_lower_funnel_shifts_op)
+        subprocess.run(cmd_lower_funnel_shifts_op, shell=True, check=True, text=True,
+                       stdout=self.logfile, stderr=self.logfile_err, bufsize=1)
+        self.logfile.write("\nFinished lower_funnel_shifts_pass\n")
+        self.curr_llfile_fullpath = output_llfile_fullpath
+
+    def run_inline_verifier_func_pass(self):
         inline_verifier_func_pass_fullpath = self.scriptsdir_fullpath.joinpath(
             "inline_verifier_func.sh")
         cmd_inline_verifier_func = '''{inline_verifier_func_pass_runner_sh} {path_to_llvm_file} {function_to_start_inline} {output_dir} {output_filename_ll}'''
+        output_llfile_fullpath = self.curr_llfile_fullpath.parent.joinpath(
+            self.curr_llfile_fullpath.stem + ".ivf" + ".ll")
         cmd_inline_verifier_func_op = cmd_inline_verifier_func.format(
             inline_verifier_func_pass_runner_sh=inline_verifier_func_pass_fullpath,
-            path_to_llvm_file=input_llfile_fullpath,
-            function_to_start_inline=function_name,
-            output_dir=outdir_fullpath,
-            output_filename_ll=output_llfile_name
+            path_to_llvm_file=self.curr_llfile_fullpath,
+            function_to_start_inline=self.function_name,
+            output_dir=output_llfile_fullpath.parent,
+            output_filename_ll=output_llfile_fullpath.name
         )
         self.logfile.write("Running inline_verifier_func_pass\n")
         self.logfile.write(cmd_inline_verifier_func_op)
         self.logfile.write("\n")
+        # print(cmd_inline_verifier_func_op)
         subprocess.run(cmd_inline_verifier_func_op, shell=True, check=True, text=True,
                        stdout=self.logfile, stderr=self.logfile_err, bufsize=1)
         self.logfile.write("\nFinished inline_verifier_func_pass\n")
+        self.curr_llfile_fullpath = output_llfile_fullpath
 
-    def run_promote_memcpy_pass(self, input_llfile_fullpath, function_name, outdir_fullpath, output_llfile_name):
+    def run_promote_memcpy_pass(self):
         promote_memcpy_pass_fullpath = self.scriptsdir_fullpath.joinpath(
             "promote_memcpy.sh")
         cmd_promote_memcpy = '''{promote_memcpy_pass_runner_sh} {path_to_llvm_file} {function_to_promote_memcpy} {output_dir} {output_filename_ll}'''
+        output_llfile_fullpath = self.curr_llfile_fullpath.parent.joinpath(
+            self.curr_llfile_fullpath.stem + ".pmc" + ".ll")
         cmd_promote_memcpy_op = cmd_promote_memcpy.format(
             promote_memcpy_pass_runner_sh=promote_memcpy_pass_fullpath,
-            path_to_llvm_file=input_llfile_fullpath,
-            function_to_promote_memcpy=function_name,
-            output_dir=outdir_fullpath,
-            output_filename_ll=output_llfile_name
+            path_to_llvm_file=self.curr_llfile_fullpath,
+            function_to_promote_memcpy=self.function_name,
+            output_dir=output_llfile_fullpath.parent,
+            output_filename_ll=output_llfile_fullpath.name
         )
         self.logfile.write("Running promote_memcpy_pass\n")
         self.logfile.write(cmd_promote_memcpy_op)
         self.logfile.write("\n")
+        # print(cmd_promote_memcpy_op)
         subprocess.run(cmd_promote_memcpy_op, shell=True, check=True, text=True,
                        stdout=self.logfile, stderr=self.logfile_err, bufsize=1)
         self.logfile.write("\nFinished promote_memcpy_pass\n")
+        self.curr_llfile_fullpath = output_llfile_fullpath
 
-    def run_llvm_to_smt_pass(self, indir_fullpath, input_llfile_name, function_name, global_bv_suffix, output_smtfile_name):
+    def run_llvm_to_smt_pass(self):
         llvm_to_smt_pass_fullpath = self.scriptsdir_fullpath.joinpath(
             "llvm_to_smt.sh")
         cmd_llvm_to_smt = '''{llvm_to_smt_pass_runner_sh} {indir_fullpath} {input_llfile_name} {function_name} {global_bv_suffix} {output_smtfile_name}'''
         cmd_llvm_to_smt_op = cmd_llvm_to_smt.format(
             llvm_to_smt_pass_runner_sh=llvm_to_smt_pass_fullpath,
-            indir_fullpath=indir_fullpath,
-            input_llfile_name=input_llfile_name,
-            function_name=function_name,
-            global_bv_suffix=global_bv_suffix,
-            output_smtfile_name=output_smtfile_name
+            indir_fullpath=self.curr_llfile_fullpath.parent,
+            input_llfile_name=self.curr_llfile_fullpath.name,
+            function_name=self.function_name,
+            global_bv_suffix=self.global_bv_suffix,
+            output_smtfile_name=self.output_smtfile_name
         )
         self.logfile.write("Running llvm_to_smt_pass\n")
         self.logfile.write(cmd_llvm_to_smt_op)
         self.logfile.write("\n")
+        # print(cmd_llvm_to_smt_op)
         subprocess.run(cmd_llvm_to_smt_op, shell=True, check=True, text=True,
                        stdout=self.logfile, stderr=self.logfile_err, bufsize=1)
         self.logfile.write("\nFinished llvm_to_smt_pass\n")
 
-    def run(self):
-        input_llfile_fullpath = str(
-            self.inputdir_fullpath.joinpath(self.input_llfile_name))
-        output_llfile_op_fullpath = self.inputdir_fullpath.joinpath(
-            "{}.ll".format(self.op))
+    def run_llvm_extract(self):
+        # extract
+        llvm_extract_fullpath = self.llvmdir_fullpath.joinpath(
+            "bin", "llvm-extract")
+        output_llfile_fullpath = self.curr_llfile_fullpath.parent.joinpath(
+            self.curr_llfile_fullpath.stem + ".ex" + ".ll")
+        cmd_extract = [str(llvm_extract_fullpath), '--func={}'.format(self.function_name),
+                       '-S', str(self.curr_llfile_fullpath), '-o', str(output_llfile_fullpath)]
+        self.logfile.write("Running llvm-extract\n")
+        self.logfile.write(" ".join(cmd_extract))
+        self.logfile.write("\n")
+        # print(cmd_extract)
+        cmdout_extract = subprocess.run(
+            cmd_extract, stdout=self.logfile, stderr=self.logfile_err, text=True, bufsize=1, check=True)
+        self.logfile.write("\nFinished running llvm-extract\n")
+        # self.curr_llfile_fullpath = output_llfile_fullpath
 
-        self.run_opt_pass(input_llfile_fullpath, output_llfile_op_fullpath)
-        self.run_force_function_early_exit_pass(
-            output_llfile_op_fullpath, self.inputdir_fullpath, "{}.ll".format(self.op))
-        self.run_opt_pass(output_llfile_op_fullpath, output_llfile_op_fullpath)
-        self.run_remove_functions_calls_pass(
-            output_llfile_op_fullpath, self.function_name, self.inputdir_fullpath, "{}.ll".format(self.op))
-        self.run_opt_pass(output_llfile_op_fullpath, output_llfile_op_fullpath)
-        self.run_inline_verifier_func_pass(
-            output_llfile_op_fullpath, self.function_name, self.inputdir_fullpath, "{}.ll".format(self.op))
-        self.run_opt_pass(output_llfile_op_fullpath, output_llfile_op_fullpath)
-        self.run_promote_memcpy_pass(output_llfile_op_fullpath,
-                                     self.function_name, self.inputdir_fullpath, "{}.ll".format(self.op))
-        self.run_opt_pass(output_llfile_op_fullpath,
-                          output_llfile_op_fullpath, O1=False)
-        self.run_llvm_to_smt_pass(self.inputdir_fullpath, "{}.ll".format(
-            self.op), self.function_name, self.global_bv_suffix, "{}.smt2".format(self.op))
+    def run(self):
+        self.create_op_dir()
+        self.run_opt_pass(O1=True)
+
+        self.run_force_function_early_exit_pass()
+        self.run_opt_pass(O1=True)
+
+        self.run_remove_functions_calls_pass()
+        self.run_opt_pass(O1=True)
+
+        self.run_inline_verifier_func_pass()
+        self.run_opt_pass(O1=True)
+
+        self.run_promote_memcpy_pass()
+        self.run_opt_pass(O1=False)
+
+        self.run_lower_funnel_shifts_pass()
+        self.run_inline_verifier_func_pass()
+
+        self.run_llvm_extract()
+
+        self.run_llvm_to_smt_pass()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--llvmdir", help="llvm install directory", type=str,
+                        required=True, default="/usr/")
+    parser.add_argument("--scriptsdir", help="scripts directory from llvm-to-smt",
+                        type=str, required=True)
+    parser.add_argument("--outdir", help="directory to use for ll/smt files", type=str,
+                        required=True)
+    parser.add_argument(
+        "--llfile", help="input LLVM file name path", required=True)
+    parser.add_argument(
+        "--funcname", help="function to encode within", required=True)
+    parser.add_argument("--op", help="BPF op", required=True)
+    args = parser.parse_args()
+
+    outdir_fullpath = Path(args.outdir).resolve()
+    scriptsdir_fullpath = Path(args.scriptsdir).resolve()
+    llvmdir_fullpath = Path(args.llvmdir).resolve()
+    inputfile_fullpath = Path(args.llfile)
+
+    assert (outdir_fullpath.exists() and scriptsdir_fullpath.exists()
+            and llvmdir_fullpath.exists())
+
+    logdir_fullpath = outdir_fullpath
+
+    logfile_name = datetime.now().strftime('log_%H_%M_%d_%m_%Y.log')
+    logfile_path = Path.joinpath(logdir_fullpath, logfile_name)
+    logfile_path.touch()
+    logfile = logfile_path.open("w")
+    logfile_err_name = datetime.now().strftime('log_err_%H_%M_%d_%m_%Y.log')
+    logfile_err_path = Path.joinpath(logdir_fullpath, logfile_err_name)
+    logfile_err_path.touch()
+    logfile_err = logfile_err_path.open("w")
+
+    print("Log file: {}".format(logfile_path))
+    print("Log error file: {}".format(logfile_err_path))
+
+    llvmpassrunner_for_op = LLVMPassRunner(
+        logfile=logfile,
+        logfile_err=logfile_err,
+        scriptsdir_fullpath=scriptsdir_fullpath,
+        llvmdir_fullpath=llvmdir_fullpath,
+        inputdir_fullpath=outdir_fullpath,
+        input_llfile_fullpath=inputfile_fullpath,
+        op=args.op,
+        function_name=args.funcname,
+        output_smtfile_name="{}.smt2".format(args.op),
+        global_bv_suffix="1")
+
+    llvmpassrunner_for_op.run()

--- a/llvm-to-smt/run_llvm_passes.py
+++ b/llvm-to-smt/run_llvm_passes.py
@@ -33,22 +33,24 @@ class LLVMPassRunner:
         self.logfile.write(
             "Creating directory and file for op: {}\n".format(self.op))
         try:
+            # TODO, remove try-catch, fail on error
             self.op_dir_fullpath.mkdir()
         except FileExistsError:
             pass
         op_llfile_fullpath = self.op_dir_fullpath.joinpath(
             '{}.ll'.format(self.op))
-        # print(op_llfile_fullpath)
+        print(op_llfile_fullpath)
         copy2(str(self.input_llfile_fullpath), str(op_llfile_fullpath))
         self.curr_llfile_fullpath = op_llfile_fullpath
 
     def run_opt_pass(self, O1=True):
         llvm_opt_fullpath = self.llvmdir_fullpath.joinpath("bin", "opt")
-        cmd_opt_O1 = '''{llvm_opt_fullpath} -O1 --strip-debug --instnamer --stats -S  {input_llfile_fullpath} -o {output_llfile_fullpath}'''
-        cmd_opt_O0 = '''{llvm_opt_fullpath} -S --instnamer --simplifycfg --sroa --mergereturn --dce --deadargelim --memoryssa --always-inline --function-attrs --argpromotion --instcombine {input_llfile_fullpath} -o {output_llfile_fullpath}'''
+        cmd_opt_O1 = '''{llvm_opt_fullpath} -Oz --strip-debug --instnamer --stats -S  {input_llfile_fullpath} -o {output_llfile_fullpath}'''
+        # cmd_opt_O0 = '''{llvm_opt_fullpath} -S --instnamer --simplifycfg --sroa --mergereturn --dce --deadargelim --memoryssa --always-inline --function-attrs --argpromotion --instcombine {input_llfile_fullpath} -o {output_llfile_fullpath}'''
+        cmd_opt_O0 = '''{llvm_opt_fullpath} -S --instnamer --sroa --adce --bdce --dce --globaldce --deadargelim --unreachableblockelim --lowerswitch --function-attrs --argpromotion {input_llfile_fullpath} -o {output_llfile_fullpath}'''
         if O1 == True:
             output_llfile_fullpath = self.curr_llfile_fullpath.parent.joinpath(
-                self.curr_llfile_fullpath.stem + ".O1" + ".ll")
+                self.curr_llfile_fullpath.stem + ".Oz" + ".ll")
             cmd_opt = cmd_opt_O1.format(
                 llvm_opt_fullpath=llvm_opt_fullpath,
                 input_llfile_fullpath=str(self.curr_llfile_fullpath),
@@ -68,7 +70,7 @@ class LLVMPassRunner:
             self.logfile.write("Running opt -O0\n")
             self.logfile.write(cmd_opt)
             self.logfile.write("\n")
-        # print(cmd_opt)
+        print(cmd_opt)
         subprocess.run(cmd_opt, shell=True, check=True, text=True,
                        stdout=self.logfile, stderr=self.logfile_err, bufsize=1)
         self.logfile.write("\nFinished running opt\n")
@@ -89,7 +91,7 @@ class LLVMPassRunner:
         self.logfile.write("Running force_function_early_exit_pass\n")
         self.logfile.write(cmd_force_functions_early_exit_op)
         self.logfile.write("\n")
-        # print(cmd_force_functions_early_exit_op)
+        print(cmd_force_functions_early_exit_op)
         subprocess.run(cmd_force_functions_early_exit_op, shell=True, check=True,
                        text=True, stdout=self.logfile, stderr=self.logfile_err, bufsize=1)
         self.logfile.write("\nFinished force_function_early_exit_pass\n")
@@ -111,7 +113,7 @@ class LLVMPassRunner:
         self.logfile.write("Running remove_functions_calls_pass\n")
         self.logfile.write(cmd_remove_func_calls_op)
         self.logfile.write("\n")
-        # print(cmd_remove_func_calls_op)
+        print(cmd_remove_func_calls_op)
         subprocess.run(cmd_remove_func_calls_op, shell=True, check=True, text=True,
                        stdout=self.logfile, stderr=self.logfile_err, bufsize=1)
         self.logfile.write("\nFinished remove_functions_calls_pass\n")
@@ -133,7 +135,7 @@ class LLVMPassRunner:
         self.logfile.write("Running lower_funnel_shifts_pass\n")
         self.logfile.write(cmd_lower_funnel_shifts_op)
         self.logfile.write("\n")
-        # print(cmd_lower_funnel_shifts_op)
+        print(cmd_lower_funnel_shifts_op)
         subprocess.run(cmd_lower_funnel_shifts_op, shell=True, check=True, text=True,
                        stdout=self.logfile, stderr=self.logfile_err, bufsize=1)
         self.logfile.write("\nFinished lower_funnel_shifts_pass\n")
@@ -155,7 +157,7 @@ class LLVMPassRunner:
         self.logfile.write("Running inline_verifier_func_pass\n")
         self.logfile.write(cmd_inline_verifier_func_op)
         self.logfile.write("\n")
-        # print(cmd_inline_verifier_func_op)
+        print(cmd_inline_verifier_func_op)
         subprocess.run(cmd_inline_verifier_func_op, shell=True, check=True, text=True,
                        stdout=self.logfile, stderr=self.logfile_err, bufsize=1)
         self.logfile.write("\nFinished inline_verifier_func_pass\n")
@@ -177,7 +179,7 @@ class LLVMPassRunner:
         self.logfile.write("Running promote_memcpy_pass\n")
         self.logfile.write(cmd_promote_memcpy_op)
         self.logfile.write("\n")
-        # print(cmd_promote_memcpy_op)
+        print(cmd_promote_memcpy_op)
         subprocess.run(cmd_promote_memcpy_op, shell=True, check=True, text=True,
                        stdout=self.logfile, stderr=self.logfile_err, bufsize=1)
         self.logfile.write("\nFinished promote_memcpy_pass\n")
@@ -198,7 +200,7 @@ class LLVMPassRunner:
         self.logfile.write("Running llvm_to_smt_pass\n")
         self.logfile.write(cmd_llvm_to_smt_op)
         self.logfile.write("\n")
-        # print(cmd_llvm_to_smt_op)
+        print(cmd_llvm_to_smt_op)
         subprocess.run(cmd_llvm_to_smt_op, shell=True, check=True, text=True,
                        stdout=self.logfile, stderr=self.logfile_err, bufsize=1)
         self.logfile.write("\nFinished llvm_to_smt_pass\n")
@@ -214,7 +216,7 @@ class LLVMPassRunner:
         self.logfile.write("Running llvm-extract\n")
         self.logfile.write(" ".join(cmd_extract))
         self.logfile.write("\n")
-        # print(cmd_extract)
+        print(cmd_extract)
         cmdout_extract = subprocess.run(
             cmd_extract, stdout=self.logfile, stderr=self.logfile_err, text=True, bufsize=1, check=True)
         self.logfile.write("\nFinished running llvm-extract\n")
@@ -229,7 +231,7 @@ class LLVMPassRunner:
 
         self.run_remove_functions_calls_pass()
         self.run_opt_pass(O1=True)
-
+        
         self.run_inline_verifier_func_pass()
         self.run_opt_pass(O1=True)
 
@@ -238,11 +240,12 @@ class LLVMPassRunner:
 
         self.run_lower_funnel_shifts_pass()
         self.run_inline_verifier_func_pass()
+        
+        self.run_opt_pass(O1=False)
 
         self.run_llvm_extract()
-
         self.run_llvm_to_smt_pass()
-
+        
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()

--- a/llvm-to-smt/run_llvm_passes.py
+++ b/llvm-to-smt/run_llvm_passes.py
@@ -47,7 +47,7 @@ class LLVMPassRunner:
         llvm_opt_fullpath = self.llvmdir_fullpath.joinpath("bin", "opt")
         cmd_opt_O1 = '''{llvm_opt_fullpath} -Oz --strip-debug --instnamer --stats -S  {input_llfile_fullpath} -o {output_llfile_fullpath}'''
         # cmd_opt_O0 = '''{llvm_opt_fullpath} -S --instnamer --simplifycfg --sroa --mergereturn --dce --deadargelim --memoryssa --always-inline --function-attrs --argpromotion --instcombine {input_llfile_fullpath} -o {output_llfile_fullpath}'''
-        cmd_opt_O0 = '''{llvm_opt_fullpath} -S --instnamer --sroa --adce --bdce --dce --globaldce --deadargelim --unreachableblockelim --lowerswitch --function-attrs --argpromotion {input_llfile_fullpath} -o {output_llfile_fullpath}'''
+        cmd_opt_O0 = '''{llvm_opt_fullpath} -S --instnamer --sroa --adce --bdce --dce --globaldce --deadargelim --unreachableblockelim --lowerswitch --function-attrs --argpromotion --instcombine {input_llfile_fullpath} -o {output_llfile_fullpath}'''
         if O1 == True:
             output_llfile_fullpath = self.curr_llfile_fullpath.parent.joinpath(
                 self.curr_llfile_fullpath.stem + ".Oz" + ".ll")

--- a/llvm-to-smt/tests/select_on_pointers.ll
+++ b/llvm-to-smt/tests/select_on_pointers.ll
@@ -1,0 +1,52 @@
+; ModuleID = 'verifier.ll'
+source_filename = "verifier.c"
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+%struct.bpf_reg_state = type { i32, i32, i32, %struct.tnum, i64, i64, i64, i64, i32, i32, i32, i32, i32, i32, %struct.bpf_reg_state*, i32, i32, i32, i8 }
+%struct.tnum = type { i64, i64 }
+
+; Function Attrs: noinline nounwind uwtable
+define dso_local void @check_cond_jmp_op_wrapper_BPF_JEQ(%struct.bpf_reg_state* %dst_reg, %struct.bpf_reg_state* %src_reg, %struct.bpf_reg_state* %other_branch_dst_reg, %struct.bpf_reg_state* %other_branch_src_reg) local_unnamed_addr #0 align 16 {
+  %tnum = getelementptr inbounds %struct.bpf_reg_state, %struct.bpf_reg_state* %src_reg, i64 0, i32 3
+  ; %tnum_value = getelementptr inbounds %struct.tnum, %struct.tnum* %tnum, i64 0, i32 0
+  %tnum_mask = getelementptr inbounds %struct.tnum, %struct.tnum* %tnum, i64 0, i32 1
+  ; %tnum_value_load = load i64, i64* %tnum_value, align 8
+  ; store i64 %tnum_value_load, i64* %tnum_mask, align 8
+  %tnum_mask_load = load i64, i64* %tnum_mask, align 8
+  %tnum_is_known = icmp eq i64 %tnum_mask_load, 0
+  ; ite(tnum_mask_load_bv == 0, tnum_is_known_bv == 1, tnum_is_known_bv == 0)
+  %select_false_reg = select i1 %tnum_is_known, %struct.bpf_reg_state* %src_reg, %struct.bpf_reg_state* %dst_reg
+  ; SelectMap: select_false_reg, tnum_is_known, src_reg, dst_reg
+  %tnum_value_false_reg = getelementptr inbounds %struct.bpf_reg_state, %struct.bpf_reg_state* %select_false_reg, i64 0, i32 3, i32 0
+  ; GEPMap: tnum_value_false_reg, select_false_reg, 3, 0
+  %tnum_value_false_reg_load = load i64, i64* %tnum_value_false_reg, align 8
+  ; ite(tnum_is_known_bv == 1, tnum_value_false_reg_load == src_reg_3_0, tnum_value_false_reg_load == dst_reg_3_0)
+  %tnum_mask_is_unknown = icmp eq i64 %tnum_mask_load, 18446744073709551615
+  ; ite(tnum_mask_load_bv == 18446744073709551615, tnum_mask_is_unknown_bv == 1, tnum_mask_is_unknown_bv == 0)
+  %select_true_reg = select i1 %tnum_mask_is_unknown, %struct.bpf_reg_state* %other_branch_dst_reg, %struct.bpf_reg_state* %other_branch_src_reg
+  ; SelectMap: select_true_reg, tnum_mask_is_unknown, other_branch_dst_reg, other_branch_src_reg
+  %tnum_value_true_reg = getelementptr inbounds %struct.bpf_reg_state, %struct.bpf_reg_state* %select_true_reg, i64 0, i32 3, i32 0
+  ; GEPMap: tnum_value_true_reg, select_true_reg, 3, 0
+  store i64 %tnum_value_false_reg_load, i64* %tnum_value_true_reg, align 8
+  ; other_branch_dst_reg: [other_dst_bv_0, other_dst_bv_1, other_dst_bv_2, [select_store_bv_0, other_dst_bv_4], other_dst_bv_5, ...]
+  ; other_branch_src_reg: [other_src_bv_0, other_src_bv_1, other_src_bv_2, [select_store_bv_1, other_src_bv_4], other_src_bv_5, ...]
+  ; assert in bbassetionsMap:
+  ; ite(tnum_mask_is_unknown == 1, select_store_bv_0 == tnum_value_false_reg_load_bv, select_store_bv_0 == other_dst_bv_3)
+  ; ite(tnum_mask_is_unknown == 0, select_store_bv_1 == tnum_value_false_reg_load_bv, select_store_bv_1 == other_src_bv_3)
+
+  ret void
+}
+
+attributes #0 = { alwaysinline norecurse nounwind readnone uwtable willreturn "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #1 = { alwaysinline nounwind uwtable "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #2 = { "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #3 = { argmemonly nofree nosync nounwind willreturn }
+attributes #4 = { noinline nounwind uwtable "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #5 = { nounwind }
+
+!llvm.module.flags = !{!0}
+!llvm.ident = !{!1}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{!"clang version 12.0.1 (https://github.com/llvm/llvm-project.git fed41342a82f5a3a9201819a82bf7a48313e296b)"}

--- a/llvm-to-smt/wrappers.py
+++ b/llvm-to-smt/wrappers.py
@@ -650,6 +650,65 @@ wrapper32_jmp_6 = wrapper_jmp_6.replace(
     "check_cond_jmp_op_wrapper", "check_cond_jmp_op_wrapper_32")
 wrapper32_jmp_6 = wrapper32_jmp_6.replace("BPF_JMP_REG", "BPF_JMP32_REG")
 
+# Andrii's patchset
+wrapper_jmp_7 = '''
+
+void check_cond_jmp_op_wrapper_{}(struct bpf_reg_state *dst_reg,
+			       struct bpf_reg_state *src_reg,
+			       struct bpf_reg_state *other_branch_dst_reg,
+			       struct bpf_reg_state *other_branch_src_reg)
+{{
+	/* Setup */
+	struct bpf_insn insn;
+	u8 opcode;
+	bool is_jmp32;
+	int pred = -1;
+
+	insn = BPF_JMP_REG({}, BPF_REG_1, BPF_REG_2, 0);
+	opcode = BPF_OP(insn.code);
+	dst_reg->type = SCALAR_VALUE;
+	src_reg->type = SCALAR_VALUE;
+
+	/* Perform custom push_stack to make sure we have don't have garbage values
+	 * for other_branch_regs in case pred != -1
+	 */
+	push_stack___(other_branch_dst_reg, dst_reg);
+	push_stack___(other_branch_src_reg, src_reg);
+
+	/* Kernel copy-pasted code begins */
+	is_jmp32 = BPF_CLASS(insn.code) == BPF_JMP32;
+	pred = is_branch_taken(dst_reg, src_reg, opcode, is_jmp32);
+
+	if (pred == 1) {{
+		return;
+	}} else if (pred == 0) {{
+		return;
+	}}
+
+	if (BPF_SRC(insn.code) == BPF_X) {{
+		reg_set_min_max(other_branch_dst_reg,
+				other_branch_src_reg,
+				dst_reg, src_reg, opcode, is_jmp32);
+
+		if (!is_jmp32 && (opcode == BPF_JEQ || opcode == BPF_JNE)) {{
+			/* Comparing for equality, we can combine knowledge */
+			reg_combine_min_max(other_branch_dst_reg,
+				other_branch_dst_reg,
+				src_reg, dst_reg, opcode);
+		}}
+	}} else /* BPF_SRC(insn.code) == BPF_K */ {{
+		reg_combine_min_max(other_branch_src_reg,
+			other_branch_dst_reg,
+			src_reg, dst_reg, opcode);
+	}}
+
+}}
+'''
+
+wrapper32_jmp_7 = wrapper_jmp_7.replace(
+    "check_cond_jmp_op_wrapper", "check_cond_jmp_op_wrapper_32")
+wrapper32_jmp_7 = wrapper32_jmp_7.replace("BPF_JMP_REG", "BPF_JMP32_REG")
+
 wrapper_sync_1 = r'''
 
 void sync___(struct bpf_reg_state *dst_reg)
@@ -681,5 +740,26 @@ void sync___(struct bpf_reg_state *dst_reg)
 	__reg_bound_offset(dst_reg);
 	__update_reg_bounds(dst_reg);
 }
+
+'''
+
+wrapper_sync_4 = r'''
+
+void sync___(struct bpf_reg_state *reg)
+{
+	/* We might have learned new bounds from the var_off. */
+	__update_reg_bounds(reg);
+	/* We might have learned something about the sign bit. */
+	__reg_deduce_bounds(reg);
+	__reg_deduce_bounds(reg);
+	/* We might have learned some bits from the bounds. */
+	__reg_bound_offset(reg);
+	/* Intersecting with the old var_off might have improved our bounds
+	 * slightly, e.g. if umax was 0x7f...f and var_off was (0; 0xf...fc),
+	 * then new var_off is (0; 0x7f...fc) which improves our umax.
+	 */
+	__update_reg_bounds(reg);
+}
+
 
 '''


### PR DESCRIPTION
1. Handle select instructions that select on pointer types (e.g. `struct.bpf_reg_state`). This involves handling loads from and stores to pointers derived from the result of such a select instruction. 

```
%select_on_ptrs = select i1 %select_value, %struct.bpf_reg_state* %src_reg, 
                       %struct.bpf_reg_state* %dst_reg
%gep_ptr_load = getelementptr %bpf_reg_state, %bpf_reg_state* %select_on_ptrs, i64 0, i32 0
%load_value = load i32, i32* %gep_ptr_load, align 8
%gep_ptr_store = getelementptr %bpf_reg_state, %bpf_reg_state* %select_on_ptrs, i64 0, i32 5
store i64 0, i64* %gep_ptr_store, align 8
```

2. Handle loads and stores to pointers derived from phi instructions that chooses on pointer types (e.g. `struct.bpf_reg_state`). Again, this involves handling loads from and stores to pointers derived from the result of such a phi instruction. 

```
%phi_reg = phi %struct.bpf_reg_state* [ %dst_reg, %ltrue ], [ %src_reg, %entry ]
%gep_ptr_load = getelementptr %bpf_reg_state, %bpf_reg_state* %phi_reg, i64 0, i32 0
%load_value = load i32, i32* %gep_ptr_load, align 8
%gep_ptr_store = getelementptr %bpf_reg_state, %bpf_reg_state* %phi_reg, i64 0, i32 5
store i64 0, i64* %gep_ptr_store, align 8

```
 
3. Handle stores to phi pointers, where the phi pointer itself chooses between values themselves derived from a previous phi. 

```
%phi_min = phi i64* [ %umin_phi, %lyes ], [ %smin_phi, %lno ]
store i64 4, i64* %phi_min, align 8
```
where, previously, 
```
%phi_reg = phi
      %struct.bpf_reg_state* [ %dst_reg, %ltrue ], [ %src_reg, %lfalse ]
%umin_phi = getelementptr inbounds %struct.bpf_reg_state,
            %struct.bpf_reg_state* %phi_reg, i64 0, i32 1
```
and similarly, for `smin_phi`