### PR TITLE
llvm-to-smt: Fix `--kernver` argument

### DIFF
--- a/llvm-to-smt/generate_encodings.py
+++ b/llvm-to-smt/generate_encodings.py
@@ -471,8 +471,11 @@ if __name__ == "__main__":
     ###################
     # checkout kernel #
     ###################
-    print_and_log("Checkout kernel version v{}".format(args.kernver), pend="")
-    cmd_checkout = ['git', 'checkout', '-f', '{}'.format(args.commit)]
+    checkout = args.commit
+    if checkout == None:
+        checkout = "v%s" % args.kernver
+    print_and_log("Checkout kernel version {}".format(checkout), pend="")
+    cmd_checkout = ['git', 'checkout', '-f', '{}'.format(checkout)]
     print()
     print(cmd_checkout)
     subprocess.run(cmd_checkout, stdout=logfile, stderr=logfile_err,


### PR DESCRIPTION
Passing a kernel version currently fails with:

    $ python3 generate_encodings.py --kernver 6.7 --kernbasedir ~/linux --outdir /home/paul/agni/bpf-encodings/6.7
    Log file: /home/paul/agni/bpf-encodings/6.7/log_19_18_29_02_2024.log
    Log error file: /home/paul/agni/bpf-encodings/6.7/log_err_19_18_29_02_2024.log
    Change to kernel directory: /home/paul/linux ... done
    Checkout kernel version v6.7
    ['git', 'checkout', '-f', 'None']
    Traceback (most recent call last):
      File "/home/paul/agni/llvm-to-smt/generate_encodings.py", line 478, in <module>
        subprocess.run(cmd_checkout, stdout=logfile, stderr=logfile_err,
      File "/usr/lib/python3.10/subprocess.py", line 526, in run
        raise CalledProcessError(retcode, process.args,
    subprocess.CalledProcessError: Command '['git', 'checkout', '-f', 'None']' returned non-zero exit status 1.

This commit fixes it.

Fixes: 27a7030e19 ("Begin handling Andrii's patchset")