### PR TITLE
.gitattributes: Fix GitHub language statistics

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-reproduce-results/bpf-encodings/** linguist-generated
+bpf-encodings/** linguist-generated


### PR DESCRIPTION
The repository with all the generated SMT code was moved so we need to update .gitattributes as well.

Fixes: 989c5b3828 ("Move bpf encodings to top-level directory")