### PR TITLE
workflows: CI for the verification step

### DIFF
--- a/.github/workflows/bpf-verification.yaml
+++ b/.github/workflows/bpf-verification.yaml
@@ -1,0 +1,40 @@
+name: BPF Verification Tests
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+  push:
+    branches:
+      - main
+jobs:
+  bpf-verification:
+    continue-on-error: true
+    strategy:
+      matrix:
+        insn: [BPF_AND, BPF_JSLT]
+        kernel: [5.9]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install dependencies
+        run: |
+          sudo apt-get install -y --no-install-recommends \
+            python3 python3-pip \
+            libjsoncpp-dev \
+            libz3-dev
+      - name: Check out repository code
+        uses: actions/checkout@v4
+      - name: Install Python dependencies
+        run: |
+          pip install -r requirements.txt
+          cd bpf-verification
+          pip install .
+      - name: Verify ${{ matrix.insn }} on v${{ matrix.kernel }}
+        run: |
+          mkdir results
+          cd bpf-verification
+          python3 src/bpf_alu_jmp_synthesis.py --kernver ${{ matrix.kernel }} --encodings_path ../bpf-encodings/${{ matrix.kernel }}/ --res_path ../results --ver_set ${{ matrix.insn }}
+      - name: Display results
+        run: |
+          ls results


### PR DESCRIPTION
This commit adds a GitHub CI test for `bpf_alu_jmp_synthesis.py` and related logic. It is currently limited to the v5.9 kernel as newer kernels easily take hours to verify a single instruction (cf. https://github.com/bpfverif/agni/issues/13). It's also limited to two instructions (one jump, one ALU) among the fatest to verify. Total verification time appears to be <5min.

This workflow will run for pull request (when opened or updated) and for all pushes to main. If several commits are pushed to main at the same time, it should only run for the latest commit of the batch.

There is a lot that can be improved: running this only when `bpf-verification/` is modified, covering more kernels and instructions, checking the results, etc. I chose to start with something small we can improve later on.

Coverage for llvm-to-smt is still a work in progress as I'm hitting weird some memory consumption behavior on GitHub.

Updates https://github.com/bpfverif/agni/issues/16.