### PR TITLE
llvm-to-smt: Use LLVM 14.0.0

### DIFF
--- a/.github/workflows/llvm-to-smt.yml
+++ b/.github/workflows/llvm-to-smt.yml
@@ -20,15 +20,10 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get install -y \
-            clang-12 llvm-12 llvm-12-tools llvm \
+            clang-14 llvm-14 llvm-14-tools llvm \
             python3 python3-pip \
             make cmake libelf-dev \
             libjsoncpp-dev stress-ng
-          # Necessary because on latest Ubuntu, LLVM 14 is the default.
-          for b in clang clang++ llvm-link opt; do
-            sudo rm /usr/bin/$b
-            sudo ln -s /usr/bin/$b-12 /usr/bin/$b
-          done
       - name: Check out repository code
         uses: actions/checkout@v4
       - name: Install Python dependencies

--- a/llvm-to-smt/generate_encodings.py
+++ b/llvm-to-smt/generate_encodings.py
@@ -328,15 +328,14 @@ def mark_reg_known_memset_remove(verifier_c_filepath):
             if r"void __mark_reg_known(" in line:
                 func_start_found = True
             if func_start_found and "memset" in line:
-                line = r'//' + line
                 num_parens_open = line.count("(")
                 num_parens_close = line.count(")")
                 while (num_parens_open != num_parens_close):
                     next_line = next(input_file_line_iter)
                     num_parens_open += next_line.count("(")
                     num_parens_close += next_line.count(")")
-                    line += r'//' + next_line
                 memset_removal_done = True
+                continue
             tmpfile_handle.write(line)
         else:
             tmpfile_handle.write(line)
@@ -367,15 +366,14 @@ def mark_reg_unknown_memset_remove(verifier_c_filepath):
                 if "struct bpf_reg_state *reg)" in next_line and "{" in next_next_line:
                     func_start_found = True
             if func_start_found and "memset" in line:
-                line = r'//' + line
                 num_parens_open = line.count("(")
                 num_parens_close = line.count(")")
                 while (num_parens_open != num_parens_close):
                     next_line = next(input_file_line_iter)
                     num_parens_open += next_line.count("(")
                     num_parens_close += next_line.count(")")
-                    line += r'//' + next_line
                 memset_removal_done = True
+                continue
             tmpfile_handle.write(line)
         else:
             tmpfile_handle.write(line)

--- a/llvm-to-smt/llvm-passes/ForceFunctionEarlyExit/CMakeLists.txt
+++ b/llvm-to-smt/llvm-passes/ForceFunctionEarlyExit/CMakeLists.txt
@@ -11,7 +11,7 @@ set(LT_LLVM_INSTALL_DIR "" CACHE PATH "LLVM installation directory")
 # find_package can locate it)
 list(APPEND CMAKE_PREFIX_PATH "${LT_LLVM_INSTALL_DIR}/lib/cmake/llvm/")
 
-find_package(LLVM 12.0.0 REQUIRED CONFIG)
+find_package(LLVM 14.0.0 REQUIRED CONFIG)
 
 # LLVMToSMT includes headers from LLVM - update the include paths accordingly
 include_directories(SYSTEM ${LLVM_INCLUDE_DIRS})

--- a/llvm-to-smt/llvm-passes/InlineFunctionCalls/CMakeLists.txt
+++ b/llvm-to-smt/llvm-passes/InlineFunctionCalls/CMakeLists.txt
@@ -11,7 +11,7 @@ set(LT_LLVM_INSTALL_DIR "" CACHE PATH "LLVM installation directory")
 # find_package can locate it)
 list(APPEND CMAKE_PREFIX_PATH "${LT_LLVM_INSTALL_DIR}/lib/cmake/llvm/")
 
-find_package(LLVM 12.0.0 REQUIRED CONFIG)
+find_package(LLVM 14.0.0 REQUIRED CONFIG)
 
 # LLVMToSMT includes headers from LLVM - update the include paths accordingly
 include_directories(SYSTEM ${LLVM_INCLUDE_DIRS})

--- a/llvm-to-smt/llvm-passes/InlineFunctionCalls/InlineFunctionCalls.cpp
+++ b/llvm-to-smt/llvm-passes/InlineFunctionCalls/InlineFunctionCalls.cpp
@@ -99,7 +99,7 @@ PreservedAnalyses InlineFunctionCalls::run(llvm::Module &M,
     raw_ostream *outfileStream = &outs();
     std::error_code EC;
     outfileStream =
-        new raw_fd_ostream(inlinedFuncOutputFile, EC, sys::fs::F_None);
+        new raw_fd_ostream(inlinedFuncOutputFile, EC, sys::fs::OF_None);
     functionToInline->print(*outfileStream);
   }
 

--- a/llvm-to-smt/llvm-passes/LLVMToSMT/CMakeLists.txt
+++ b/llvm-to-smt/llvm-passes/LLVMToSMT/CMakeLists.txt
@@ -11,7 +11,7 @@ set(LT_LLVM_INSTALL_DIR "" CACHE PATH "LLVM installation directory")
 # find_package can locate it)
 list(APPEND CMAKE_PREFIX_PATH "${LT_LLVM_INSTALL_DIR}/lib/cmake/llvm/")
 
-find_package(LLVM 12.0.0 REQUIRED CONFIG)
+find_package(LLVM 14.0.0 REQUIRED CONFIG)
 
 # LLVMToSMT includes headers from LLVM - update the include paths accordingly
 include_directories(SYSTEM ${LLVM_INCLUDE_DIRS})

--- a/llvm-to-smt/llvm-passes/LowerFunnelShifts/CMakeLists.txt
+++ b/llvm-to-smt/llvm-passes/LowerFunnelShifts/CMakeLists.txt
@@ -11,7 +11,7 @@ set(LT_LLVM_INSTALL_DIR "" CACHE PATH "LLVM installation directory")
 # find_package can locate it)
 list(APPEND CMAKE_PREFIX_PATH "${LT_LLVM_INSTALL_DIR}/lib/cmake/llvm/")
 
-find_package(LLVM 12.0.0 REQUIRED CONFIG)
+find_package(LLVM 14.0.0 REQUIRED CONFIG)
 
 # LLVMToSMT includes headers from LLVM - update the include paths accordingly
 include_directories(SYSTEM ${LLVM_INCLUDE_DIRS})

--- a/llvm-to-smt/llvm-passes/PromoteMemcpy/CMakeLists.txt
+++ b/llvm-to-smt/llvm-passes/PromoteMemcpy/CMakeLists.txt
@@ -11,7 +11,7 @@ set(LT_LLVM_INSTALL_DIR "" CACHE PATH "LLVM installation directory")
 # find_package can locate it)
 list(APPEND CMAKE_PREFIX_PATH "${LT_LLVM_INSTALL_DIR}/lib/cmake/llvm/")
 
-find_package(LLVM 12.0.0 REQUIRED CONFIG)
+find_package(LLVM 14.0.0 REQUIRED CONFIG)
 
 # LLVMToSMT includes headers from LLVM - update the include paths accordingly
 include_directories(SYSTEM ${LLVM_INCLUDE_DIRS})

--- a/llvm-to-smt/llvm-passes/PromoteMemcpy/PromoteMemcpy.cpp
+++ b/llvm-to-smt/llvm-passes/PromoteMemcpy/PromoteMemcpy.cpp
@@ -169,7 +169,7 @@ bool PromoteMemcpy::simplifyMemCpy(MemCpyInst *MI) {
     assert(Ty == TrDst->getType());
 
     if (!Ty->isStructTy()) {
-      auto *NewLoad = Builder.CreateLoad(TrSrc, SrcPtr->getName() + ".pmcpy");
+      auto *NewLoad = Builder.CreateLoad(TrSrc->getType()->getPointerElementType(), TrSrc, SrcPtr->getName() + ".pmcpy");
       auto *NewStore = Builder.CreateStore(NewLoad, TrDst);
 
       outs() << "New load-store:\n\t";

--- a/llvm-to-smt/llvm-passes/RemoveFunctionCalls/CMakeLists.txt
+++ b/llvm-to-smt/llvm-passes/RemoveFunctionCalls/CMakeLists.txt
@@ -11,7 +11,7 @@ set(LT_LLVM_INSTALL_DIR "" CACHE PATH "LLVM installation directory")
 # find_package can locate it)
 list(APPEND CMAKE_PREFIX_PATH "${LT_LLVM_INSTALL_DIR}/lib/cmake/llvm/")
 
-find_package(LLVM 12.0.0 REQUIRED CONFIG)
+find_package(LLVM 14.0.0 REQUIRED CONFIG)
 
 # LLVMToSMT includes headers from LLVM - update the include paths accordingly
 include_directories(SYSTEM ${LLVM_INCLUDE_DIRS})

--- a/llvm-to-smt/run_llvm_passes.py
+++ b/llvm-to-smt/run_llvm_passes.py
@@ -57,12 +57,12 @@ class LLVMPassRunner:
 
     def run_opt_pass(self, O1=True):
         llvm_opt_fullpath = self.llvmdir_fullpath.joinpath("bin", "opt")
-        cmd_opt_O1 = '''{llvm_opt_fullpath} -Oz --strip-debug --instnamer --stats -S  {input_llfile_fullpath} -o {output_llfile_fullpath}'''
+        cmd_opt_O1 = '''{llvm_opt_fullpath} -O1 --strip-debug --instnamer --stats -S  {input_llfile_fullpath} -o {output_llfile_fullpath}'''
         # cmd_opt_O0 = '''{llvm_opt_fullpath} -S --instnamer --simplifycfg --sroa --mergereturn --dce --deadargelim --memoryssa --always-inline --function-attrs --argpromotion --instcombine {input_llfile_fullpath} -o {output_llfile_fullpath}'''
         cmd_opt_O0 = '''{llvm_opt_fullpath} -S --instnamer --sroa --adce --bdce --dce --globaldce --deadargelim --unreachableblockelim --lowerswitch --function-attrs --argpromotion --instcombine {input_llfile_fullpath} -o {output_llfile_fullpath}'''
         if O1 == True:
             output_llfile_fullpath = self.curr_llfile_fullpath.parent.joinpath(
-                self.curr_llfile_fullpath.stem + ".Oz" + ".ll")
+                self.curr_llfile_fullpath.stem + ".O1" + ".ll")
             cmd_opt = cmd_opt_O1.format(
                 llvm_opt_fullpath=llvm_opt_fullpath,
                 input_llfile_fullpath=str(self.curr_llfile_fullpath),


### PR DESCRIPTION
Since Linux commit [9c1b86f8ce04e](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=9c1b86f8ce04e) ("kbuild: raise the minimum supported version of LLVM to 13.0.1"), which is `v6.9-rc1~106^2~38`, the kernel requires LLVM 13.0.1 to compile.

We therefore need to upgrade our LLVM dependency to be able to run Agni against latest kernels. Upgrading past LLVM 15 is a lot more work because typed pointers were replaced by opaque pointers, but we should be able to upgrade to LLVM 14.

Two changes are needed in the sources to adapt to changes in the LLVM API:
- `sys::fs::F_None` was renamed to `sys::fs::OF_None`.
- The handy `Builder.CreateLoad` functions that take only two arguments have been removed.

Fixes: https://github.com/bpfverif/agni/issues/26.