### PR TITLE
Update generate encodings scripts for better logging and encoding generation

### DIFF
--- a/llvm-to-smt/generate_encodings.py
+++ b/llvm-to-smt/generate_encodings.py
@@ -534,12 +534,13 @@ if __name__ == "__main__":
     #  setup logging   #
     ####################
     logdir_fullpath = outdir_fullpath
+    datetime_str = datetime.now().strftime('%H_%M_%d_%m_%Y')
 
-    logfile_name = datetime.now().strftime('log_%H_%M_%d_%m_%Y.log')
+    logfile_name = datetime.now().strftime('log_{}.log'.format(datetime_str))
     logfile_path = pathlib.Path.joinpath(logdir_fullpath, logfile_name)
     logfile_path.touch()
     logfile = logfile_path.open("w")
-    logfile_err_name = datetime.now().strftime('log_err_%H_%M_%d_%m_%Y.log')
+    logfile_err_name = datetime.now().strftime('log_err_{}.log'.format(datetime_str))
     logfile_err_path = pathlib.Path.joinpath(logdir_fullpath, logfile_err_name)
     logfile_err_path.touch()
     logfile_err = logfile_err_path.open("w")
@@ -738,8 +739,6 @@ if __name__ == "__main__":
         print(colored("Getting encoding for {}".format(
             op), 'green'), flush=True)
         llvmpassrunner_for_op = LLVMPassRunner(
-            logfile=logfile,
-            logfile_err=logfile_err,
             scriptsdir_fullpath=scriptsdir_fullpath,
             llvmdir_fullpath=llvmdir_fullpath,
             inputdir_fullpath=outdir_fullpath,
@@ -747,7 +746,9 @@ if __name__ == "__main__":
             input_llfile_fullpath=input_llfile_fullpath,
             function_name="adjust_scalar_min_max_vals_wrapper_{}".format(op),
             output_smtfile_name="{}.smt2".format(op),
-            global_bv_suffix=str(i))
+            global_bv_suffix=str(i),
+            logfile_name = logfile_name,
+            logfile_err_name = logfile_err_name)
         try:
             llvmpassrunner_for_op.run()
         except subprocess.CalledProcessError as e:
@@ -763,8 +764,6 @@ if __name__ == "__main__":
         print(colored("Getting encoding for {}".format(
             op32), 'green'), flush=True)
         llvmpassrunner_for_op = LLVMPassRunner(
-            logfile=logfile,
-            logfile_err=logfile_err,
             scriptsdir_fullpath=scriptsdir_fullpath,
             llvmdir_fullpath=llvmdir_fullpath,
             inputdir_fullpath=outdir_fullpath,
@@ -773,7 +772,9 @@ if __name__ == "__main__":
             function_name="adjust_scalar_min_max_vals_wrapper_{}".format(
                 op32),
             output_smtfile_name="{}.smt2".format(op32),
-            global_bv_suffix=str(i))
+            global_bv_suffix=str(i),
+            logfile_name = logfile_name,
+            logfile_err_name = logfile_err_name)
         try:
             llvmpassrunner_for_op.run()
         except subprocess.CalledProcessError as e:
@@ -788,8 +789,6 @@ if __name__ == "__main__":
         print(colored("Getting encoding for {}".format(
             op), 'green'), flush=True)
         llvmpassrunner_for_op = LLVMPassRunner(
-            logfile=logfile,
-            logfile_err=logfile_err,
             scriptsdir_fullpath=scriptsdir_fullpath,
             llvmdir_fullpath=llvmdir_fullpath,
             inputdir_fullpath=outdir_fullpath,
@@ -797,7 +796,9 @@ if __name__ == "__main__":
             input_llfile_fullpath=input_llfile_fullpath,
             function_name="check_cond_jmp_op_wrapper_{}".format(op),
             output_smtfile_name="{}.smt2".format(op),
-            global_bv_suffix=str(i))
+            global_bv_suffix=str(i),
+            logfile_name = logfile_name,
+            logfile_err_name = logfile_err_name)
         try:
             llvmpassrunner_for_op.run()
         except subprocess.CalledProcessError as e:
@@ -815,8 +816,6 @@ if __name__ == "__main__":
             print(colored("Getting encoding for {}".format(
                 op32), 'green'), flush=True)
             llvmpassrunner_for_op = LLVMPassRunner(
-                logfile=logfile,
-                logfile_err=logfile_err,
                 scriptsdir_fullpath=scriptsdir_fullpath,
                 llvmdir_fullpath=llvmdir_fullpath,
                 inputdir_fullpath=outdir_fullpath,
@@ -824,7 +823,9 @@ if __name__ == "__main__":
                 input_llfile_fullpath=input_llfile_fullpath,
                 function_name="check_cond_jmp_op_wrapper_{}".format(op32),
                 output_smtfile_name="{}.smt2".format(op32),
-                global_bv_suffix=str(i))
+                global_bv_suffix=str(i),
+                logfile_name = logfile_name,
+                logfile_err_name = logfile_err_name)
             try:
                 llvmpassrunner_for_op.run()
             except subprocess.CalledProcessError as e:
@@ -839,8 +840,6 @@ if __name__ == "__main__":
         print(colored("Getting encoding for {}".format(
             op), 'green'), flush=True)
         llvmpassrunner_for_op = LLVMPassRunner(
-            logfile=logfile,
-            logfile_err=logfile_err,
             scriptsdir_fullpath=scriptsdir_fullpath,
             llvmdir_fullpath=llvmdir_fullpath,
             inputdir_fullpath=outdir_fullpath,
@@ -848,7 +847,9 @@ if __name__ == "__main__":
             input_llfile_fullpath=input_llfile_fullpath,
             function_name=bpf_refinement_ops[op],
             output_smtfile_name="{}.smt2".format(op),
-            global_bv_suffix=str(i))
+            global_bv_suffix=str(i),
+            logfile_name = logfile_name,
+            logfile_err_name = logfile_err_name)
         try:
             llvmpassrunner_for_op.run()
         except subprocess.CalledProcessError as e:

--- a/llvm-to-smt/wrappers.py
+++ b/llvm-to-smt/wrappers.py
@@ -100,8 +100,7 @@ void adjust_scalar_min_max_vals_wrapper_{}(struct bpf_reg_state *dst_reg,
 }}
 """
 
-wrapper_alu32_1 = wrapper_alu_1.replace(
-    "adjust_scalar_min_max_vals_wrapper", "adjust_scalar_min_max_vals_wrapper_32").replace("BPF_ALU64_REG", "BPF_ALU32_REG")
+wrapper_alu32_1 = wrapper_alu_1.replace("BPF_ALU64_REG", "BPF_ALU32_REG")
 
 
 # 4.14.214 to 4.16-rc1
@@ -369,9 +368,7 @@ void check_cond_jmp_op_wrapper_{}(struct bpf_reg_state *dst_reg,
 
 '''
 
-wrapper_jmp32_3 = wrapper_jmp_3.replace(
-    "check_cond_jmp_op_wrapper", "check_cond_jmp_op_wrapper_32")
-wrapper_jmp32_3 = wrapper_jmp32_3.replace("BPF_JMP_REG", "BPF_JMP32_REG")
+wrapper_jmp32_3 = wrapper_jmp_3.replace("BPF_JMP_REG", "BPF_JMP32_REG")
 
 # 5.3-rc1 to 5.7-rc1
 wrapper_jmp_4 = '''
@@ -457,9 +454,7 @@ void check_cond_jmp_op_wrapper_{}(struct bpf_reg_state *dst_reg,
 
 '''
 
-wrapper_jmp32_4 = wrapper_jmp_4.replace(
-    "check_cond_jmp_op_wrapper", "check_cond_jmp_op_wrapper_32")
-wrapper_jmp32_4 = wrapper_jmp32_4.replace("BPF_JMP_REG", "BPF_JMP32_REG")
+wrapper_jmp32_4 = wrapper_jmp_4.replace("BPF_JMP_REG", "BPF_JMP32_REG")
 
 # 5.7-rc1+
 wrapper_jmp_5 = '''
@@ -545,9 +540,7 @@ void check_cond_jmp_op_wrapper_{}(struct bpf_reg_state *dst_reg,
 
 '''
 
-wrapper_jmp32_5 = wrapper_jmp_5.replace(
-    "check_cond_jmp_op_wrapper", "check_cond_jmp_op_wrapper_32")
-wrapper_jmp32_5 = wrapper_jmp32_5.replace("BPF_JMP_REG", "BPF_JMP32_REG")
+wrapper_jmp32_5 = wrapper_jmp_5.replace("BPF_JMP_REG", "BPF_JMP32_REG")
 
 # 6.4-rc1+
 wrapper_jmp_6 = '''
@@ -646,9 +639,7 @@ void check_cond_jmp_op_wrapper_{}(struct bpf_reg_state *dst_reg,
 
 '''
 
-wrapper_jmp32_6 = wrapper_jmp_6.replace(
-    "check_cond_jmp_op_wrapper", "check_cond_jmp_op_wrapper_32")
-wrapper_jmp32_6 = wrapper_jmp32_6.replace("BPF_JMP_REG", "BPF_JMP32_REG")
+wrapper_jmp32_6 = wrapper_jmp_6.replace("BPF_JMP_REG", "BPF_JMP32_REG")
 
 # Andrii's patchset cd9c127069c0
 wrapper_jmp_cd9c127069c0 = '''
@@ -706,8 +697,6 @@ void check_cond_jmp_op_wrapper_{}(struct bpf_reg_state *dst_reg,
 '''
 
 wrapper_jmp32_cd9c127069c0 = wrapper_jmp_cd9c127069c0.replace(
-    "check_cond_jmp_op_wrapper", "check_cond_jmp_op_wrapper_32")
-wrapper_jmp32_cd9c127069c0 = wrapper_jmp32_cd9c127069c0.replace(
     "BPF_JMP_REG", "BPF_JMP32_REG")
 
 # v6.8-rc1+
@@ -760,9 +749,7 @@ void check_cond_jmp_op_wrapper_{}(
 }}
 '''
 
-wrapper_jmp32_7 = wrapper_jmp_7.replace(
-    "check_cond_jmp_op_wrapper", "check_cond_jmp_op_wrapper_32")
-wrapper_jmp32_7 = wrapper_jmp32_7.replace("BPF_JMP_REG", "BPF_JMP32_REG")
+wrapper_jmp32_7 = wrapper_jmp_7.replace("BPF_JMP_REG", "BPF_JMP32_REG")
 
 wrapper_sync_1 = r'''
 
@@ -784,8 +771,8 @@ void reg_bounds_sync___(struct bpf_reg_state *dst_reg)
 }
 '''
 
-# Note jumps (__reg_combine_64_into_32, __reg_combine_32_into_64)
-# had the following (different) order <5.19: 
+# Note: jumps pre 5.19 (__reg_combine_64_into_32, __reg_combine_32_into_64)
+# had the following (different) order:
 # -	__reg_deduce_bounds(reg);
 # -	__reg_bound_offset(reg);
 # -	__update_reg_bounds(reg);
@@ -804,7 +791,7 @@ wrapper_sync_4 = r'''
 void reg_bounds_sync___(struct bpf_reg_state *dst_reg)
 {
 	struct bpf_verifier_env env;
-	reg_bounds_sync(dst_reg);    
+	reg_bounds_sync(dst_reg);
     reg_bounds_sanity_check(&env, dst_reg, "dst_reg");
 }
 


### PR DESCRIPTION
This series of commits: 
1. Allows generating the 32-bit and 64-bit op encodings separately when using `--separate-op`
2. Moves the logging for each "op" into a separate log file created in the op directory.
3. Fixes a minor nit in the wrapper function names.