### PR TITLE
workflows/llvm-to-smt: Cover more kernels

### DIFF
--- a/.github/workflows/llvm-to-smt.yml
+++ b/.github/workflows/llvm-to-smt.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         insn: [BPF_AND]
-        kernel: [5.9, 6.8]
+        kernel: ["5.9", "6.8", "linus"]
     runs-on: ubuntu-latest
     steps:
       - name: Install dependencies
@@ -31,7 +31,11 @@ jobs:
           pip install -r requirements.txt
       - name: Retrieve Linux sources
         run: |
-          git clone -qb v${{ matrix.kernel }} --depth 1 git://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
+          branch=v${{ matrix.kernel }}
+          if [ "${{ matrix.kernel }}" = "linus" ]; then
+            branch=master
+          fi
+          git clone -qb $branch --depth 1 git://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
       - name: Generate encodings
         run: |
           cd "${{ github.workspace }}/linux"
@@ -39,8 +43,12 @@ jobs:
           cd -
           mkdir -p bpf-encodings/${{ matrix.kernel }}
           cd llvm-to-smt
+          version=v${{ matrix.kernel }}
+          if [ "${{ matrix.kernel }}" = "linus" ]; then
+            version="6.10"
+          fi
           python3 generate_encodings.py \
-            --kernver ${{ matrix.kernel }} --commit $commit \
+            --kernver $version --commit $commit \
             --kernbasedir "${{ github.workspace }}/linux" \
             --outdir ../bpf-encodings/${{ matrix.kernel }} \
             --specific-op ${{ matrix.insn }}

--- a/.github/workflows/llvm-to-smt.yml
+++ b/.github/workflows/llvm-to-smt.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         insn: [BPF_AND]
-        kernel: ["5.9", "6.8", "linus"]
+        kernel: ["5.9", "6.8", "linus", "bpf-next"]
     runs-on: ubuntu-latest
     steps:
       - name: Install dependencies
@@ -32,10 +32,14 @@ jobs:
       - name: Retrieve Linux sources
         run: |
           branch=v${{ matrix.kernel }}
+          tree=git://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
           if [ "${{ matrix.kernel }}" = "linus" ]; then
             branch=master
+          elif [ "${{ matrix.kernel }}" = "bpf-next" ]; then
+            tree=git://git.kernel.org/pub/scm/linux/kernel/git/bpf/bpf-next.git
+            branch=master
           fi
-          git clone -qb $branch --depth 1 git://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
+          git clone -qb $branch --depth 1 $tree linux
       - name: Generate encodings
         run: |
           cd "${{ github.workspace }}/linux"
@@ -44,7 +48,7 @@ jobs:
           mkdir -p bpf-encodings/${{ matrix.kernel }}
           cd llvm-to-smt
           version=v${{ matrix.kernel }}
-          if [ "${{ matrix.kernel }}" = "linus" ]; then
+          if [ "${{ matrix.kernel }}" = "linus" ] || [ "${{ matrix.kernel }}" = "bpf-next" ]; then
             version="6.10"
           fi
           python3 generate_encodings.py \


### PR DESCRIPTION
Cover the latest linus and bpf-next trees in the LLVM-to-SMT workflow.