### PR TITLE
llvm-to-smt: wrappers for v6.10

### DIFF
--- a/llvm-to-smt/generate_encodings.py
+++ b/llvm-to-smt/generate_encodings.py
@@ -105,7 +105,11 @@ def get_all_jmp_wrappers_concatenated(kernver):
     wrapper_jmp = ''
     wrapper_jmp32 = ''
 
-    if version.parse(kernver) >= version.parse("6.8-rc1"):
+    if version.parse(kernver) >= version.parse("6.10-rc5"):
+        # Starting with v6.10-rc5~30^2~33^2~6
+        wrapper_jmp = wrapper_jmp_8
+        wrapper_jmp32 = wrapper_jmp32_8
+    elif version.parse(kernver) >= version.parse("6.8-rc1"):
         # Starting with v6.8-rc1~131^2~289^2~25.
         wrapper_jmp = wrapper_jmp_7
         wrapper_jmp32 = wrapper_jmp32_7

--- a/llvm-to-smt/wrappers.py
+++ b/llvm-to-smt/wrappers.py
@@ -831,6 +831,93 @@ void check_cond_jmp_op_wrapper_{}(
 
 wrapper_jmp32_7 = wrapper_jmp_7.replace("BPF_JMP_REG", "BPF_JMP32_REG")
 
+wrapper_jmp_8 = '''
+void check_cond_jmp_op_wrapper_{}(
+	struct bpf_reg_state *dst_reg, struct bpf_reg_state *src_reg,
+	struct bpf_reg_state *other_branch_dst_reg,
+	struct bpf_reg_state *other_branch_src_reg)
+{{
+	struct bpf_verifier_env env;
+	struct bpf_insn insn = BPF_JMP_REG({}, BPF_REG_1, BPF_REG_2, 0);
+	dst_reg->type = SCALAR_VALUE;
+	src_reg->type = SCALAR_VALUE;
+
+    // Perform custom push_stack to make sure other_branch_*_regs
+    // are equal to dst/src_reg. This needs to be done here rather
+    // than later (as it appears in kernel code), otherwise
+    // other_branch_dst/src_reg will be free to take on any value
+    // in the SMT formula when pred == 1 or pred == 0 below, which
+    // will then lead to a false positive counterexample.
+	push_stack___(other_branch_dst_reg, dst_reg);
+	push_stack___(other_branch_src_reg, src_reg);
+
+    // ---------------------------------------------------------------
+    //  Kernel copy-pasted code begins
+    // ---------------------------------------------------------------
+	struct bpf_reg_state fake_reg[2];
+	u8 opcode = BPF_OP(insn.code);
+	bool is_jmp32;
+	int pred = -1;
+	int err;
+
+	if (BPF_SRC(insn.code) == BPF_X) {{
+		if (insn.imm != 0) {{
+			return;
+		}}
+
+	}} else {{
+		if (insn.src_reg != BPF_REG_0) {{
+			return;
+		}}
+		src_reg = &fake_reg[0];
+		src_reg->type = SCALAR_VALUE;
+		__mark_reg_known(src_reg, insn.imm);
+	}}
+
+	is_jmp32 = BPF_CLASS(insn.code) == BPF_JMP32;
+	pred = is_branch_taken(dst_reg, src_reg, opcode, is_jmp32);
+	if (pred >= 0) {{
+		/* If we get here with a dst_reg pointer type it is because
+		 * above is_branch_taken() special cased the 0 comparison.
+		 */
+	}}
+
+	if (pred == 1) {{
+		/* Only follow the goto, ignore fall-through. If needed, push
+		 * the fall-through branch for simulation under speculative
+		 * execution.
+		 */
+		return;
+	}} else if (pred == 0) {{
+		/* Only follow the fall-through branch, since that's where the
+		 * program will go. If needed, push the goto branch for
+		 * simulation under speculative execution.
+		 */
+		return;
+	}}
+
+	if (BPF_SRC(insn.code) == BPF_X) {{
+		err = reg_set_min_max(&env,
+				      other_branch_dst_reg,
+				      other_branch_src_reg,
+				      dst_reg, src_reg, opcode, is_jmp32);
+	}} else /* BPF_SRC(insn.code) == BPF_K */ {{
+	    push_stack___(&fake_reg[1], &fake_reg[0]);
+		err = reg_set_min_max(&env,
+				      other_branch_dst_reg,
+				      &fake_reg[0],
+				      dst_reg, &fake_reg[1],
+				      opcode, is_jmp32);
+	}}
+	if (err)
+		return;
+
+	return;
+}}
+'''
+
+wrapper_jmp32_8 = wrapper_jmp_8.replace("BPF_JMP_REG", "BPF_JMP32_REG")
+
 wrapper_sync_1 = r'''
 
 void reg_bounds_sync___(struct bpf_reg_state *dst_reg)


### PR DESCRIPTION
This commit updates the wrappers for v6.10-rc5 and above, specifically including the idea in commit [1].
While this doesn't affect the encodings for BPF_JMP_REG instructions, it will be useful when addressing
BPF_JMP_IMM types, and addressing [2].

[1]: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?id=92424801261d1564a0bb759da3cf3ccd69fdf5a2
[2]: https://github.com/bpfverif/agni/issues/40