### PR TITLE
workflows: Cleanup

### DIFF
--- a/.github/workflows/bpf-verification.yaml
+++ b/.github/workflows/bpf-verification.yaml
@@ -8,6 +8,7 @@ on:
   push:
     branches:
       - main
+
 jobs:
   bpf-verification:
     continue-on-error: true
@@ -24,14 +25,18 @@ jobs:
             python3 python3-pip \
             libjsoncpp-dev \
             libz3-dev
+
       - name: Check out repository code
         uses: actions/checkout@v4
+
       - name: Install Python dependencies
         run: |
           pip install -r requirements.txt
           cd bpf-verification
           pip install .
+
       - name: Verify ${{ matrix.insn }} on v${{ matrix.kernel }}
+        id: bpf-verification
         run: |
           mkdir results
           cd bpf-verification
@@ -42,6 +47,7 @@ jobs:
             --ver_set ${{ matrix.insn }}
 
       - name: Upload artifacts
+        if: ${{ always() }} && steps.bpf-verification.outcome != 'skipped'
         uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4.3.4
         with:
           name: results-${{ matrix.kernel }}-${{ matrix.insn }}-${{ matrix.spec }}

--- a/.github/workflows/llvm-to-smt.yml
+++ b/.github/workflows/llvm-to-smt.yml
@@ -8,6 +8,7 @@ on:
   push:
     branches:
       - main
+
 jobs:
   llvm-to-smt:
     continue-on-error: true
@@ -24,11 +25,14 @@ jobs:
             python3 python3-pip \
             make cmake libelf-dev \
             libjsoncpp-dev stress-ng
+
       - name: Check out repository code
         uses: actions/checkout@v4
+
       - name: Install Python dependencies
         run: |
           pip install -r requirements.txt
+
       - name: Retrieve Linux sources
         run: |
           branch=v${{ matrix.kernel }}
@@ -55,6 +59,7 @@ jobs:
           rm -r .git
 
       - name: Generate encodings
+        id: generate-encodings
         run: |
           set -o xtrace
 
@@ -75,6 +80,7 @@ jobs:
             --specific-op ${{ matrix.insn }}
 
       - name: Upload artifacts
+        if: ${{ always() }} && steps.generate-encodings.outcome != 'skipped'
         uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4.3.4
         with:
           name: bpf-encodings-${{ matrix.kernel }}-${{ matrix.insn }}

--- a/.github/workflows/llvm-to-smt.yml
+++ b/.github/workflows/llvm-to-smt.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         insn: [BPF_AND, BPF_JSLT]
-        kernel: ["5.9", "6.8", "linus", "bpf-next"]
+        kernel: ["5.9", "6.8", "6.10"]
     runs-on: ubuntu-latest
     steps:
       - name: Install dependencies


### PR DESCRIPTION
First commit removes coverage for bpf-next and linus from the pull request workflows. Second commit ensures we always upload artifacts. See commit descriptions for details.