### PR TITLE
llvm-to-smt: Support llvm.*.with.overflow.* intrinsics and extractvalue

### DIFF
--- a/.github/workflows/end-to-end.yaml
+++ b/.github/workflows/end-to-end.yaml
@@ -33,8 +33,7 @@ jobs:
     continue-on-error: true
     strategy:
       matrix:
-        # BPF_ADD* and BPF_SUB* are excluded for now due to a kernel regression wrt to encoding generation.
-        insn: [BPF_SYNC, BPF_OR, BPF_AND, BPF_XOR, BPF_LSH, BPF_RSH, BPF_ARSH, BPF_JLT, BPF_JLE, BPF_JSLT, BPF_JSLE, BPF_JEQ, BPF_JNE, BPF_JGE, BPF_JGT, BPF_JSGE, BPF_JSGT, BPF_OR_32, BPF_AND_32, BPF_XOR_32, BPF_LSH_32, BPF_RSH_32, BPF_ARSH_32, BPF_JLT_32, BPF_JLE_32, BPF_JSLT_32, BPF_JSLE_32, BPF_JEQ_32, BPF_JNE_32, BPF_JGE_32, BPF_JGT_32, BPF_JSGE_32, BPF_JSGT_32]
+        insn: [BPF_SYNC, BPF_ADD, BPF_SUB, BPF_OR, BPF_AND, BPF_XOR, BPF_LSH, BPF_RSH, BPF_ARSH, BPF_JLT, BPF_JLE, BPF_JSLT, BPF_JSLE, BPF_JEQ, BPF_JNE, BPF_JGE, BPF_JGT, BPF_JSGE, BPF_JSGT, BPF_ADD_32, BPF_SUB_32, BPF_OR_32, BPF_AND_32, BPF_XOR_32, BPF_LSH_32, BPF_RSH_32, BPF_ARSH_32, BPF_JLT_32, BPF_JLE_32, BPF_JSLT_32, BPF_JSLE_32, BPF_JEQ_32, BPF_JNE_32, BPF_JGE_32, BPF_JGT_32, BPF_JSGE_32, BPF_JSGT_32]
         tree: ["torvalds_linux", "bpf_bpf-next"]
     runs-on: ubuntu-latest
     steps:

--- a/llvm-to-smt/llvm-passes/LLVMToSMT/FunctionEncoder.hpp
+++ b/llvm-to-smt/llvm-passes/LLVMToSMT/FunctionEncoder.hpp
@@ -112,10 +112,10 @@ public:
 
   std::unordered_map<Value *, std::vector<ValueBBPair>> PhiMap;
 
-  /* Associate with each BasicBlock, a ValueBVTreeMap; to resolve
-   * to resolve insertValue instructions (instead of piggy-backing on the
-   * MemoryAccessValueBVTreeMap). Used to store BVTrees for aggregate types.
-   * Also used for handling struct return types. */
+  /* Associate with each BasicBlock, a ValueBVTreeMap; to track insertValue
+   * instructions or intrinsic call instructions that return an aggregate type.
+   * This map will store BVTrees for aggregate types that can be retreived
+   * later. */
   std::unordered_map<BasicBlock *, ValueBVTreeMap *> BBValueBVTreeMap;
 
   /* Functions to print things */
@@ -137,6 +137,7 @@ public:
   /* Functions that handle individual llvm instructions */
   void handleCastInst(CastInst &i);
   void handleBinaryOperatorInst(BinaryOperator &i);
+  void handleExtractValueInst(ExtractValueInst &i);
   void handleReturnInstPointerArgs(ReturnInst &i);
   bool functionHasPointerArguments(Function &F);
   void handleReturnInst(ReturnInst &i);
@@ -151,6 +152,8 @@ public:
   void handleStoreInst(StoreInst &i);
   void handleMemoryPhiNode(MemoryPhi &mphi, int passID);
   void handleCallInst(CallInst &i);
+  void handleIntrinsicCallInst(IntrinsicInst &i);
+  void handleAddSubWithOverflowIntrinsic(IntrinsicInst &i);
   void handleGEPInstFromSelect(GetElementPtrInst &i);
   void handleGEPInstFromPHI(GetElementPtrInst &i);
   void handlePhiInstPointer(PHINode &inst);


### PR DESCRIPTION
This commits support for llvm add/sub intrinsics with overflow detection: llvm.sadd.with.overflow.*, llvm.uadd.with.overflow.*, llvm.ssub.with.overflow.*, llvm.usub.with.overflow.* . It also adds limited support for extractvalue instructions to support the intrinsics. This is needed in order to support BPF_ADD and BPF_SUB instructions in v6.10 [1].

The return type of the add with overflow intrinsic is an aggregate type. The types are automatically inferred and appropriate sized bitvectors are used (i32/i64/any other size) in the formula. This commit also adds support for extractvalue instructions, that typically occur *after* the intrinsic call instructions.

See the commit message and comments for details. 

[1]: https://github.com/bpfverif/agni/issues/44