### PR TITLE
Explicit insn coverage

### DIFF
--- a/llvm-to-smt/llvm-passes/LLVMToSMT/FunctionEncoder.hpp
+++ b/llvm-to-smt/llvm-passes/LLVMToSMT/FunctionEncoder.hpp
@@ -150,7 +150,7 @@ public:
   void handleReturnInst(ReturnInst &i, FunctionEncoderPassType passID);
   void handleICmpInst(ICmpInst &i);
   void handleSelectInst(SelectInst &i);
-  void handleBranchInst(BranchInst &i);
+  void handleBranchInst(BranchInst &i, FunctionEncoderPassType passID);
   void handlePhiNode(PHINode &inst, int passID);
   void handlePhiNodeSetupBitVecs(PHINode &inst);
   void handlePhiNodeResolvePathConditions(PHINode &inst);

--- a/llvm-to-smt/llvm-passes/LLVMToSMT/FunctionEncoder.hpp
+++ b/llvm-to-smt/llvm-passes/LLVMToSMT/FunctionEncoder.hpp
@@ -32,6 +32,13 @@ typedef std::pair<Value *, BasicBlock *> ValueBBPair;
 
 extern z3::context ctx;
 
+enum FunctionEncoderPassType {
+  BBAssertionsMapPass = 1,
+  PathConditionsMapPass = 2,
+  HandlePhiNodesPass = 3,
+  HandleReturnInstPass = 4
+};
+
 class FunctionEncoder {
 
 public:
@@ -140,7 +147,7 @@ public:
   void handleExtractValueInst(ExtractValueInst &i);
   void handleReturnInstPointerArgs(ReturnInst &i);
   bool functionHasPointerArguments(Function &F);
-  void handleReturnInst(ReturnInst &i);
+  void handleReturnInst(ReturnInst &i, FunctionEncoderPassType passID);
   void handleICmpInst(ICmpInst &i);
   void handleSelectInst(SelectInst &i);
   void handleBranchInst(BranchInst &i);
@@ -150,7 +157,7 @@ public:
   void handleGEPInst(GetElementPtrInst &i);
   void handleLoadInst(LoadInst &i);
   void handleStoreInst(StoreInst &i);
-  void handleMemoryPhiNode(MemoryPhi &mphi, int passID);
+  void handleMemoryPhiNode(MemoryPhi &mphi, FunctionEncoderPassType passID);
   void handleCallInst(CallInst &i);
   void handleIntrinsicCallInst(IntrinsicInst &i);
   void handleAddSubWithOverflowIntrinsic(IntrinsicInst &i);


### PR DESCRIPTION
In the future there could be new instructions which we do not support. To that end, there should be at least one function that iterates over all the instructions in llvm IR, to make sure we aren't missing anything. These commits address that. This is more of a nice-to-have, and is not a problem currently.  Commits have more details. 