### PR TITLE
workflows: Cover bpf tree in end-to-end test

### DIFF
--- a/.github/workflows/end-to-end.yaml
+++ b/.github/workflows/end-to-end.yaml
@@ -8,7 +8,7 @@ jobs:
   download-linux:
     strategy:
       matrix:
-        tree: ["torvalds_linux", "bpf_bpf-next"]
+        tree: ["torvalds_linux", "bpf_bpf-next", "bpf_bpf"]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -35,7 +35,7 @@ jobs:
     strategy:
       matrix:
         insn: [BPF_SYNC, BPF_ADD, BPF_SUB, BPF_OR, BPF_AND, BPF_XOR, BPF_LSH, BPF_RSH, BPF_ARSH, BPF_JLT, BPF_JLE, BPF_JSLT, BPF_JSLE, BPF_JEQ, BPF_JNE, BPF_JGE, BPF_JGT, BPF_JSGE, BPF_JSGT, BPF_ADD_32, BPF_SUB_32, BPF_OR_32, BPF_AND_32, BPF_XOR_32, BPF_LSH_32, BPF_RSH_32, BPF_ARSH_32, BPF_JLT_32, BPF_JLE_32, BPF_JSLT_32, BPF_JSLE_32, BPF_JEQ_32, BPF_JNE_32, BPF_JGE_32, BPF_JGT_32, BPF_JSGE_32, BPF_JSGT_32]
-        tree: ["torvalds_linux", "bpf_bpf-next"]
+        tree: ["torvalds_linux", "bpf_bpf-next", "bpf_bpf"]
     runs-on: ubuntu-latest
     timeout-minutes: 180
     steps:


### PR DESCRIPTION
Successful run can be seen here: https://github.com/bpfverif/agni/actions/runs/10539785106.