### PR TITLE
Store to phi

### DIFF
--- a/llvm-to-smt/llvm-passes/LLVMToSMT/FunctionEncoder.hpp
+++ b/llvm-to-smt/llvm-passes/LLVMToSMT/FunctionEncoder.hpp
@@ -164,10 +164,17 @@ public:
   void handleGEPInstFromSelect(GetElementPtrInst &i);
   void handleGEPInstFromPHI(GetElementPtrInst &i);
   void handlePhiInstPointer(PHINode &inst);
+  void handleStoreToGEPPtrDerivedFromFunctionArg(
+      z3::expr BVToStore, Value *destPointerValue,
+      std::vector<int> *GEPMapIndices, ValueBVTreeMap *newValueBVTreeMap,
+      MemoryUseOrDef *storeMemoryAccess);
   void handleLoadFromGEPPtrDerivedFromSelect(LoadInst &i,
                                              SelectInst &selectInst);
   void handleLoadFromGEPPtrDerivedFromPhi(LoadInst &i, PHINode &phiNode);
 
+  void handleStoreToGEPPtr(z3::expr BVToStore, GetElementPtrInst &GEPInst,
+                           ValueBVTreeMap *newValueBVTreeMap,
+                           MemoryUseOrDef *storeMemoryAccess);
   void handleStoreToGEPPtrDerivedFromSelect(z3::expr BVToStore,
                                             SelectInst &selectInst,
                                             std::vector<int> *GEPMapIndices,


### PR DESCRIPTION
Address store to phi ptrs, that should address https://github.com/bpfverif/agni/issues/39. 

The first two commits are mostly refactoring in preparation for the third commit. The third commit handles store to phi pointers, by modifying the existing handleStoreToPhiPtr() function to handle stores to only a specific type of phi pointer.
Such a phi pointer instruction chooses one of two or more pointers to store at, depending on the basic block that was taken to arrive at the phi pointer instruction.

Previously handleStoreToPhiPtr() addressed a more complicated case: store instruction that stores to a phi pointer that chooses between two pointers, which themselves were derived by indexing into another phi pointer. With llvm-14 it seems we don't need to handle this case, and instead need to handle the simpler case above.

See the third commit message for more details. It replaces handleStoreToPhiPtr() to handle the simpler case. 

I checked PR again the main branch for kernel versions 6.1 through 6.7 and this branch produced the exact same encodings as the main branch, except for the ones that the main branch errored out on. 
