### PR TITLE
generate-encodings: Add option for overriding bitvector suffixes

### DIFF
--- a/llvm-to-smt/generate_encodings.py
+++ b/llvm-to-smt/generate_encodings.py
@@ -671,6 +671,10 @@ if __name__ == "__main__":
                         help='single specific BPF op to encode',
                         choices = [op.op_name for op in bpf_ops],
                         type=str, required=False)
+    parser.add_argument("--bv-suffix-override", dest='bv_suffix_override',
+                        help='use a different bitvector suffix than the default, i.e. use default + 1000',
+                        action=argparse.BooleanOptionalAction,
+                        required=False)
     parser.add_argument("--commit",
                         help="specific kernel commit, instead of a kernel version",
                         type=str, required=False, default="-")
@@ -710,6 +714,14 @@ if __name__ == "__main__":
     if args.modular:
         # only support modular verification in kernels with "reg_bounds_sync"
         assert version.parse(args.kernver) >= version.parse("5.19-rc6")
+
+    if args.bv_suffix_override:
+        if args.specific_op is None:
+            raise RuntimeError(
+            '--bv-suffix-override can only be used with --specific-op')
+        for op in bpf_ops:
+            if op.op_name == args.specific_op:
+                op.suffix_id = op.suffix_id + 1000
 
     ####################
     #  setup logging   #


### PR DESCRIPTION
In order to compare two encodings for equivalent input-output behavior, we need the pairs of encodings to use different bitvectors names. Currently, bitvector suffixes are hardcoded in the suffix_id field of each op in bpf_ops. This commit allows overriding the default bitvector suffixes by providing a flag that replaces the hardcoded_suffix_id with hardcoded_suffix_id + 1000.