### PR TITLE
llvm-to-smt: Exit early if function is not a DAG

### DIFF
--- a/llvm-to-smt/llvm-passes/LLVMToSMT/FunctionEncoder.hpp
+++ b/llvm-to-smt/llvm-passes/LLVMToSMT/FunctionEncoder.hpp
@@ -210,6 +210,8 @@ public:
                                        std::string prefix);
   BVTree *setupBVTreeForArg(Value *argVal, std::string prefix);
   bool isRelevantStruct(StructType *s);
+
+  bool isFunctionCFGaDAG(llvm::Function &F);
   void buildSMT();
   std::string toString();
 };


### PR DESCRIPTION
In LLVMToSMT, we don’t support generating encodings for abstract operator functions with backward edges, i.e., functions whose CFG is not a DAG. This commit introduces a check to allow LLVMToSMT to exit early if the CFG of the function being encoded is not a DAG.

Previously, LLVMToSMT could generate incorrect encodings silently for abstract operators with backward edges. By adding this check, we make the failure explicit, preventing silent errors.

As a side note, in a prior kernel commit [1], we updated regs_refine_cond_op() to remove a backward edge from the CFG of abstract operators for JUMP instructions.

[1] https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?id=4c2a26fc80