### PR TITLE
workflows: Fix error reporting for the workflow runs

### DIFF
--- a/.github/workflows/bpf-verification.yaml
+++ b/.github/workflows/bpf-verification.yaml
@@ -15,8 +15,8 @@ concurrency:
 
 jobs:
   bpf-verification:
-    continue-on-error: true
     strategy:
+      fail-fast: false
       matrix:
         insn: [BPF_AND, BPF_JSLT]
         kernel: [5.9]

--- a/.github/workflows/end-to-end.yaml
+++ b/.github/workflows/end-to-end.yaml
@@ -31,8 +31,8 @@ jobs:
 
   end-to-end:
     needs: download-linux
-    continue-on-error: true
     strategy:
+      fail-fast: false
       matrix:
         insn: [BPF_SYNC, BPF_ADD, BPF_SUB, BPF_OR, BPF_AND, BPF_XOR, BPF_LSH, BPF_RSH, BPF_ARSH, BPF_JLT, BPF_JLE, BPF_JSLT, BPF_JSLE, BPF_JEQ, BPF_JNE, BPF_JGE, BPF_JGT, BPF_JSGE, BPF_JSGT, BPF_ADD_32, BPF_SUB_32, BPF_OR_32, BPF_AND_32, BPF_XOR_32, BPF_LSH_32, BPF_RSH_32, BPF_ARSH_32, BPF_JLT_32, BPF_JLE_32, BPF_JSLT_32, BPF_JSLE_32, BPF_JEQ_32, BPF_JNE_32, BPF_JGE_32, BPF_JGT_32, BPF_JSGE_32, BPF_JSGT_32]
         tree: ["torvalds_linux", "bpf_bpf-next", "bpf_bpf"]

--- a/.github/workflows/llvm-to-smt.yml
+++ b/.github/workflows/llvm-to-smt.yml
@@ -15,8 +15,8 @@ concurrency:
 
 jobs:
   llvm-to-smt:
-    continue-on-error: true
     strategy:
+      fail-fast: false
       matrix:
         insn: [BPF_AND, BPF_JSLT]
         kernel: ["5.4", "5.10", "5.15", "6.1", "6.6", "6.10"]


### PR DESCRIPTION
Commits 18b7513, 285dc20, and a30260d incorrectly used `continue-on-error` in our three workflows causing all job failures to be ignored at the workflow level. Thus, workflow runs would be reported as successful even when all their jobs were failing.

This commit fixes that by using the intended `strategy.fail-fast` [1] configuration instead. This configuration, when set to false, will prevent a single job failure from interrupting the whole workflow. Instead, other jobs will continue running and the workflow run will then be correctly reported as failed. The intent is simply to gather information on all jobs before failing the workflow.

1 - https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast Fixes: https://github.com/bpfverif/agni/pull/25
Fixes: https://github.com/bpfverif/agni/pull/42
Fixes: https://github.com/bpfverif/agni/pull/27
Updates: https://github.com/bpfverif/agni/issues/68