### PR TITLE
workflows: Fix v5.x compilation errors

### DIFF
--- a/.github/workflows/bpf-verification.yaml
+++ b/.github/workflows/bpf-verification.yaml
@@ -21,7 +21,7 @@ jobs:
         insn: [BPF_AND, BPF_JSLT]
         kernel: [5.9]
         spec: ["no-weak-spec", "weak-spec"]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 20
     steps:
       - name: Install dependencies

--- a/.github/workflows/end-to-end.yaml
+++ b/.github/workflows/end-to-end.yaml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         tree: ["torvalds_linux", "bpf_bpf-next", "bpf_bpf"]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 10
     steps:
       - name: Retrieve Linux sources
@@ -36,7 +36,7 @@ jobs:
       matrix:
         insn: [BPF_SYNC, BPF_ADD, BPF_SUB, BPF_OR, BPF_AND, BPF_XOR, BPF_LSH, BPF_RSH, BPF_ARSH, BPF_JLT, BPF_JLE, BPF_JSLT, BPF_JSLE, BPF_JEQ, BPF_JNE, BPF_JGE, BPF_JGT, BPF_JSGE, BPF_JSGT, BPF_ADD_32, BPF_SUB_32, BPF_OR_32, BPF_AND_32, BPF_XOR_32, BPF_LSH_32, BPF_RSH_32, BPF_ARSH_32, BPF_JLT_32, BPF_JLE_32, BPF_JSLT_32, BPF_JSLE_32, BPF_JEQ_32, BPF_JNE_32, BPF_JGE_32, BPF_JGT_32, BPF_JSGE_32, BPF_JSGT_32]
         tree: ["torvalds_linux", "bpf_bpf-next", "bpf_bpf"]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 180
     steps:
       - name: Install dependencies

--- a/.github/workflows/llvm-to-smt.yml
+++ b/.github/workflows/llvm-to-smt.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         insn: [BPF_AND, BPF_JSLT]
         kernel: ["5.4", "5.10", "5.15", "6.1", "6.6", "6.10"]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 40
     steps:
       - name: Install dependencies

--- a/.github/workflows/llvm-to-smt.yml
+++ b/.github/workflows/llvm-to-smt.yml
@@ -23,7 +23,17 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 40
     steps:
-      - name: Install dependencies
+      - name: Install dependencies for v5.x
+        if: ${{ startsWith(matrix.kernel, '5.') }}
+        run: |
+          sudo apt-get install -y \
+            clang-12 llvm-12 llvm-12-tools llvm \
+            python3 python3-pip \
+            make cmake libelf-dev \
+            libjsoncpp-dev stress-ng
+
+      - name: Install dependencies for v6.1+
+        if: ${{ ! startsWith(matrix.kernel, '5.') }}
         run: |
           sudo apt-get install -y \
             clang-14 llvm-14 llvm-14-tools llvm \


### PR DESCRIPTION
This should fix the LLVM-to-SMT and the End-to-End workflows. See commits for details.

Updates: https://github.com/bpfverif/agni/issues/68.