### PR TITLE
workflows: Add manual trigger to end-to-end workflow

### DIFF
--- a/.github/workflows/end-to-end.yaml
+++ b/.github/workflows/end-to-end.yaml
@@ -1,5 +1,7 @@
 name: End-to-End Tests
 on:
+  # To trigger manually.
+  workflow_dispatch:
   # Run once a day, every day.
   schedule:
     - cron:  '0 0 * * *'


### PR DESCRIPTION
This will allow us to trigger the end-to-end workflow manually, if we ever want to run it without waiting 24h.