### PR TITLE
workflows/e2e: Increase timeout

### DIFF
--- a/.github/workflows/end-to-end.yaml
+++ b/.github/workflows/end-to-end.yaml
@@ -39,7 +39,7 @@ jobs:
         insn: [BPF_SYNC, BPF_ADD, BPF_SUB, BPF_OR, BPF_AND, BPF_XOR, BPF_LSH, BPF_RSH, BPF_ARSH, BPF_JLT, BPF_JLE, BPF_JSLT, BPF_JSLE, BPF_JEQ, BPF_JNE, BPF_JGE, BPF_JGT, BPF_JSGE, BPF_JSGT, BPF_ADD_32, BPF_SUB_32, BPF_OR_32, BPF_AND_32, BPF_XOR_32, BPF_LSH_32, BPF_RSH_32, BPF_ARSH_32, BPF_JLT_32, BPF_JLE_32, BPF_JSLT_32, BPF_JSLE_32, BPF_JEQ_32, BPF_JNE_32, BPF_JGE_32, BPF_JGT_32, BPF_JSGE_32, BPF_JSGT_32]
         tree: ["torvalds_linux", "bpf_bpf-next", "bpf_bpf"]
     runs-on: ubuntu-24.04
-    timeout-minutes: 180
+    timeout-minutes: 360
     steps:
       - name: Install dependencies
         run: |


### PR DESCRIPTION
Since we merged commit [`5dbb19b16ac4`](https://git.kernel.org/pub/scm/linux/kernel/git/bpf/bpf-next.git/commit/?id=5dbb19b16ac4) upstream, to verify `BPF_SYNC`, Agni went from 1h30 to 4h30-5h. The workflow is therefore now timing out. As a short-term measure, let's increase the timeout to 6h.

A successful run is visible here: https://github.com/bpfverif/agni/actions/runs/16652987534?pr=77.