### PR TITLE
llvm-to-smt: Support llvm ctpop intrinsics, BPF_JSET

### DIFF
--- a/bpf-verification/lib_reg_bounds_tracking/lib_reg_bounds_tracking.py
+++ b/bpf-verification/lib_reg_bounds_tracking/lib_reg_bounds_tracking.py
@@ -575,6 +575,7 @@ class config_setup:
             "BPF_JGT":      self.encodings_path + "BPF_JGT.smt2",
             "BPF_JSGE":     self.encodings_path + "BPF_JSGE.smt2",
             "BPF_JSGT":     self.encodings_path + "BPF_JSGT.smt2",
+            "BPF_JSET":     self.encodings_path + "BPF_JSET.smt2",
             "BPF_OR_32":       self.encodings_path + "BPF_OR_32.smt2",
             "BPF_AND_32":      self.encodings_path + "BPF_AND_32.smt2",
             "BPF_XOR_32":      self.encodings_path + "BPF_XOR_32.smt2",
@@ -592,7 +593,8 @@ class config_setup:
             "BPF_JGE_32":      self.encodings_path + "BPF_JGE_32.smt2",
             "BPF_JGT_32":      self.encodings_path + "BPF_JGT_32.smt2",
             "BPF_JSGE_32":     self.encodings_path + "BPF_JSGE_32.smt2",
-            "BPF_JSGT_32":     self.encodings_path + "BPF_JSGT_32.smt2"
+            "BPF_JSGT_32":     self.encodings_path + "BPF_JSGT_32.smt2",
+            "BPF_JSET_32":     self.encodings_path + "BPF_JSET_32.smt2"
             }
         #synthesis insn set pool
         if isinstance(config_file["insn_set"], list):
@@ -621,17 +623,18 @@ class config_setup:
     def set_ops(self, mode):
         if mode == "ALL":
             self.OPS_set = {"BPF_AND", "BPF_OR", "BPF_LSH", "BPF_RSH", "BPF_JLT", "BPF_JLE", "BPF_JEQ", "BPF_JNE", "BPF_JGE", "BPF_JGT", "BPF_JSGE", "BPF_JSGT", "BPF_JSLT", "BPF_JSLE", "BPF_ADD", "BPF_SUB", "BPF_XOR", "BPF_ARSH",
-            "BPF_OR_32", "BPF_AND_32", "BPF_LSH_32", "BPF_RSH_32", "BPF_ADD_32", "BPF_SUB_32", "BPF_XOR_32","BPF_ARSH_32", "BPF_JLT_32",  "BPF_JLE_32", "BPF_JSLT_32", "BPF_JSLE_32", "BPF_JEQ_32", "BPF_JNE_32", "BPF_JGE_32", "BPF_JGT_32", "BPF_JSGE_32", "BPF_JSGT_32"}
+            "BPF_OR_32", "BPF_AND_32", "BPF_LSH_32", "BPF_RSH_32", "BPF_ADD_32", "BPF_SUB_32", "BPF_XOR_32","BPF_ARSH_32", "BPF_JLT_32",  "BPF_JLE_32", "BPF_JSLT_32", "BPF_JSLE_32", "BPF_JEQ_32", "BPF_JNE_32", "BPF_JGE_32", "BPF_JGT_32", "BPF_JSGE_32", "BPF_JSGT_32",
+            "BPF_JSET", "BPF_JSET_32"}
         elif mode == "ALL32":
-            self.OPS_set = {"BPF_OR_32", "BPF_AND_32", "BPF_LSH_32", "BPF_RSH_32", "BPF_ADD_32", "BPF_SUB_32", "BPF_XOR_32","BPF_ARSH_32", "BPF_JLT_32",  "BPF_JLE_32", "BPF_JSLT_32", "BPF_JSLE_32", "BPF_JEQ_32", "BPF_JNE_32", "BPF_JGE_32", "BPF_JGT_32", "BPF_JSGE_32", "BPF_JSGT_32"}
+            self.OPS_set = {"BPF_OR_32", "BPF_AND_32", "BPF_LSH_32", "BPF_RSH_32", "BPF_ADD_32", "BPF_SUB_32", "BPF_XOR_32","BPF_ARSH_32", "BPF_JLT_32",  "BPF_JLE_32", "BPF_JSLT_32", "BPF_JSLE_32", "BPF_JEQ_32", "BPF_JNE_32", "BPF_JGE_32", "BPF_JGT_32", "BPF_JSGE_32", "BPF_JSGT_32", "BPF_JSET_32"}
         elif mode =="JMP32":
-            self.OPS_set = {"BPF_JLT_32",  "BPF_JLE_32", "BPF_JSLT_32", "BPF_JSLE_32", "BPF_JEQ_32", "BPF_JNE_32", "BPF_JGE_32", "BPF_JGT_32", "BPF_JSGE_32", "BPF_JSGT_32"}
+            self.OPS_set = {"BPF_JLT_32",  "BPF_JLE_32", "BPF_JSLT_32", "BPF_JSLE_32", "BPF_JEQ_32", "BPF_JNE_32", "BPF_JGE_32", "BPF_JGT_32", "BPF_JSGE_32", "BPF_JSGT_32", "BPF_JSET_32"}
         elif mode =="ALU32":
             self.OPS_set = {"BPF_OR_32", "BPF_AND_32", "BPF_LSH_32", "BPF_RSH_32", "BPF_ADD_32", "BPF_SUB_32", "BPF_XOR_32","BPF_ARSH_32"}
         elif mode == "ALL64":
-            self.OPS_set = {"BPF_AND", "BPF_OR", "BPF_LSH", "BPF_RSH", "BPF_JLT", "BPF_JLE", "BPF_JEQ", "BPF_JNE", "BPF_JGE", "BPF_JGT", "BPF_JSGE", "BPF_JSGT", "BPF_JSLT", "BPF_JSLE", "BPF_ADD", "BPF_SUB", "BPF_XOR", "BPF_ARSH"}
+            self.OPS_set = {"BPF_AND", "BPF_OR", "BPF_LSH", "BPF_RSH", "BPF_JLT", "BPF_JLE", "BPF_JEQ", "BPF_JNE", "BPF_JGE", "BPF_JGT", "BPF_JSGE", "BPF_JSGT", "BPF_JSLT", "BPF_JSLE", "BPF_ADD", "BPF_SUB", "BPF_XOR", "BPF_ARSH", "BPF_JSET"}
         elif mode =="JMP64":
-            self.OPS_set = {"BPF_JLT", "BPF_JLE", "BPF_JEQ", "BPF_JNE", "BPF_JGE", "BPF_JGT", "BPF_JSGE", "BPF_JSGT", "BPF_JSLT", "BPF_JSLE"}
+            self.OPS_set = {"BPF_JLT", "BPF_JLE", "BPF_JEQ", "BPF_JNE", "BPF_JGE", "BPF_JGT", "BPF_JSGE", "BPF_JSGT", "BPF_JSLT", "BPF_JSLE", "BPF_JSET"}
         elif mode =="ALU64":
             self.OPS_set = {"BPF_AND", "BPF_OR", "BPF_LSH", "BPF_RSH", "BPF_ADD", "BPF_SUB", "BPF_XOR", "BPF_ARSH"}
 
@@ -865,6 +868,17 @@ class verification_synth_module:
                         self.input_dst_reg_list[i].conc64 == self.input_src_reg_list[i].conc64,
                         self.set_true_branch(i),
                         self.set_false_branch(i)))
+            elif(self.prog[i] == "BPF_JSET_32"):
+                formula.append(If(
+                        (self.input_dst_reg_list[i].conc32 & self.input_src_reg_list[i].conc32) != 0,
+                        self.set_true_branch(i),
+                        self.set_false_branch(i)))
+            elif(self.prog[i] == "BPF_JSET"):
+                formula.append(If(
+                        (self.input_dst_reg_list[i].conc64 & self.input_src_reg_list[i].conc64) != 0,
+                        self.set_true_branch(i),
+                        self.set_false_branch(i)))
+
 
     def set_true_branch(self, i):
         return And(

--- a/bpf-verification/src/bpf_alu_jmp_synthesis.py
+++ b/bpf-verification/src/bpf_alu_jmp_synthesis.py
@@ -20,7 +20,7 @@ from packaging import version
 def main():
 
     #setup argparse and customized options
-    bpf_instructions_set = ["BPF_AND", "BPF_OR", "BPF_LSH", "BPF_RSH", "BPF_JLT", "BPF_JLE", "BPF_JEQ", "BPF_JNE", "BPF_JGE", "BPF_JGT", "BPF_JSGE", "BPF_JSGT", "BPF_JSLT", "BPF_JSLE", "BPF_ADD", "BPF_SUB", "BPF_XOR", "BPF_ARSH", "BPF_OR_32", "BPF_AND_32", "BPF_LSH_32", "BPF_RSH_32", "BPF_ADD_32", "BPF_SUB_32", "BPF_XOR_32", "BPF_ARSH_32", "BPF_JLT_32", "BPF_JLE_32", "BPF_JSLT_32", "BPF_JSLE_32", "BPF_JEQ_32", "BPF_JNE_32", "BPF_JGE_32", "BPF_JGT_32", "BPF_JSGE_32", "BPF_JSGT_32"]
+    bpf_instructions_set = ["BPF_AND", "BPF_OR", "BPF_LSH", "BPF_RSH", "BPF_JLT", "BPF_JLE", "BPF_JEQ", "BPF_JNE", "BPF_JGE", "BPF_JGT", "BPF_JSGE", "BPF_JSGT", "BPF_JSLT", "BPF_JSLE", "BPF_ADD", "BPF_SUB", "BPF_XOR", "BPF_ARSH", "BPF_OR_32", "BPF_AND_32", "BPF_LSH_32", "BPF_RSH_32", "BPF_ADD_32", "BPF_SUB_32", "BPF_XOR_32", "BPF_ARSH_32", "BPF_JLT_32", "BPF_JLE_32", "BPF_JSLT_32", "BPF_JSLE_32", "BPF_JEQ_32", "BPF_JNE_32", "BPF_JGE_32", "BPF_JGT_32", "BPF_JSGE_32", "BPF_JSGT_32", "BPF_JSET", "BPF_JSET_32"]
     bpf_instructions_set_w_sync = bpf_instructions_set.copy()
     epilog = "Possible bpf instructions: %s" % ", ".join(bpf_instructions_set) + " ----- BPF_SYNC can be used only in ver_set"
     parser = argp.ArgumentParser(prog="eBPF Verification and Synthesis", epilog=epilog)

--- a/llvm-to-smt/generate_encodings.py
+++ b/llvm-to-smt/generate_encodings.py
@@ -106,7 +106,7 @@ bpf_ops.append(bpf_op_attrs(op_name='BPF_JGT', insn='BPF_JGT', insn_class='BPF_J
 bpf_ops.append(bpf_op_attrs(op_name='BPF_JGE', insn='BPF_JGE', insn_class='BPF_JMP_REG',
                             skip=False, intro_ver="3.18", suffix_id=27))
 bpf_ops.append(bpf_op_attrs(op_name='BPF_JSET', insn='BPF_JSET', insn_class='BPF_JMP_REG',
-                            skip=True, intro_ver="3.18", suffix_id=28))
+                            skip=False, intro_ver="3.18", suffix_id=28))
 bpf_ops.append(bpf_op_attrs(op_name='BPF_JNE', insn='BPF_JNE', insn_class='BPF_JMP_REG',
                             skip=False, intro_ver="3.18", suffix_id=29))
 bpf_ops.append(bpf_op_attrs(op_name='BPF_JLT', insn='BPF_JLT', insn_class='BPF_JMP_REG',
@@ -132,7 +132,7 @@ bpf_ops.append(bpf_op_attrs(op_name='BPF_JGT_32', insn='BPF_JGT', insn_class='BP
 bpf_ops.append(bpf_op_attrs(op_name='BPF_JGE_32', insn='BPF_JGE', insn_class='BPF_JMP32_REG',
                             skip=False, intro_ver="5.1", suffix_id=39))
 bpf_ops.append(bpf_op_attrs(op_name='BPF_JSET_32', insn='BPF_JSET', insn_class='BPF_JMP32_REG',
-                            skip=True, intro_ver="5.1", suffix_id=40))
+                            skip=False, intro_ver="5.1", suffix_id=40))
 bpf_ops.append(bpf_op_attrs(op_name='BPF_JNE_32', insn='BPF_JNE', insn_class='BPF_JMP32_REG',
                             skip=False, intro_ver="5.1", suffix_id=41))
 bpf_ops.append(bpf_op_attrs(op_name='BPF_JLT_32', insn='BPF_JLT', insn_class='BPF_JMP32_REG',

--- a/llvm-to-smt/llvm-passes/LLVMToSMT/FunctionEncoder.hpp
+++ b/llvm-to-smt/llvm-passes/LLVMToSMT/FunctionEncoder.hpp
@@ -162,6 +162,7 @@ public:
   void handleIntrinsicCallInst(IntrinsicInst &i);
   void handleLLVMOverflowInstrinsics(IntrinsicInst &i);
   void handleInstrinsicLLVMMax(IntrinsicInst &i);
+  void handleIntrinsicLLVMCTPop(IntrinsicInst &i);
   void handleGEPInstFromSelect(GetElementPtrInst &i);
   void handleGEPInstFromPHI(GetElementPtrInst &i);
   void handlePhiInstPointer(PHINode &inst);


### PR DESCRIPTION
In order to support BPF_JSET, we will have to add support for the llvm.ctpop intrinsic, which is does a population count of 1 bits in an integer, for example:
%o = call i4 @llvm.ctpop.i4(i4 %i)

See the first commit message for the details of generating encodings with llvm.ctpop. I was able to generate encodings for BPF_JSET, BPF_JSET_32.

The second commit adds support for BPF_JSET to bpf_alu_jmp_synthesis.py and lib_reg_bounds_tracking.py. 
