### PR TITLE
llvm-to-smt: Handle load from phi pointers

### DIFF
--- a/llvm-to-smt/llvm-passes/LLVMToSMT/FunctionEncoder.hpp
+++ b/llvm-to-smt/llvm-passes/LLVMToSMT/FunctionEncoder.hpp
@@ -173,7 +173,7 @@ public:
   void handleLoadFromGEPPtrDerivedFromSelect(LoadInst &i,
                                              SelectInst &selectInst);
   void handleLoadFromGEPPtrDerivedFromPhi(LoadInst &i, PHINode &phiNode);
-
+  void handleLoadFromPhiPtr(LoadInst &loadInst, PHINode &phiInst);
   void handleStoreToGEPPtr(z3::expr BVToStore, GetElementPtrInst &GEPInst,
                            ValueBVTreeMap *newValueBVTreeMap,
                            MemoryUseOrDef *storeMemoryAccess);


### PR DESCRIPTION
This commit adds support for load instructions that load from a phi pointer (of single value type). For example:

...
lend:
  %umin_phi = phi i64* [ %umax1, %ltrue ], [ %umax2, %lfalse ]
  %umin_phi_load = load i64, i64* %umin_phi, align 8

Here, the phi instruction chooses between two GEP pointers that were defined previously. The load instruction loads the value that the phi instruction points to.

To handle such a case, we simply set the loaded value's (umin_phi_load) bitvector ( umin_phi_load_bv) depending on the path conditions that the phi instruction were based on.

(=> lfalse_lend (= umin_phi_load_bv dst_reg_7_bv)) (=> ltrue_lend (= umin_phi_load_bv src_reg_7_bv))

Note that this commit only handles cases where the phi pointer is a single value type pointer, e.g. an i32* or an i64*. Previously, df43587aa1 handled another special case for phi pointers to *aggregate* types.

%phi_reg = phi %reg_st* [ %dst_reg, %lfalse ], [ %src_reg, %ltrue] %phi_reg_tnum_mask = getelementptr %reg_st,
                     %reg_st* %phi_reg, i64 0, i32 3, i32 1
%phi_reg_tnum_mask_load = load i64, i64* %phi_reg_tnum_mask, align 8

This support was since removed in c3d5f326a6.

Fixes #76.